### PR TITLE
Update: unify the job names

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -3,7 +3,7 @@ name: Resuable brakeman workflow
 on: workflow_call
 
 jobs:
-  brakeman-scan:
+  brakeman:
     name: scan
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -3,7 +3,8 @@ name: Resuable rspec workflow
 on: workflow_call
 
 jobs:
-  execution:
+  rspec:
+    name: scan
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -7,7 +7,8 @@ on:
         required: false
 
 jobs:
-  execution:
+  rubocop:
+    name: scan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ workflow on your remote repo by calling `ministryofjustice/laa-reusable-github-a
 
 ### Warning
 
-I have set the job name of the initial workflows as `execution` so that, when you use a header 
+I have set the job name of the initial workflows as `scan` so that, when you use a header 
 in _your_ repo it will be reflected in the calling path inside your pull request
 So if you have a pull request workflow file in your repo like so:
 ```yaml
@@ -42,24 +42,22 @@ jobs:
   rubocop:
     uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/rubocop.yml@main
 
-  rspec:
+  something:
     runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:10.11
-        ports: [ "5432:5432" ]
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         # <snip>
 ```
 Your pull request checks will resemble
 ```text
-Pull request / rubocop / execution (pull_request)
-Pull request / rspec (pull_request)
+Pull request / rubocop / scan (pull_request)
+Pull request / something (pull_request)
 ``` 
 
 So it doesn't  duplicate the  local job `rubocop` e.g.
 ```text
 Pull request / rubocop / rubocop (pull_request)
-Pull request / rspec (pull_request)
+Pull request / something (pull_request)
 ```
 


### PR DESCRIPTION
Ensure the initial workflows all use `name: scan` and update the readme to reflect