### PR TITLE
Fix: Update the github action versions

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up ruby # this should inherit from your .ruby-version
         uses: ruby/setup-ruby@v1
       - name: Setup Brakeman
@@ -21,6 +21,6 @@ jobs:
           brakeman -f sarif -o output.sarif.json .
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: output.sarif.json

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
           sudo apt install ./libffi6_3.2.1-8_amd64.deb
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up ruby
         # this should inherit from your .ruby-version
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -11,7 +11,7 @@ jobs:
     name: scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up ruby
         # this should inherit from your .ruby-version
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR:

* Updates all CodeQL actions to v2 as v1 is due to be deprecated on Jan 18th 2023
* Updates all checkout actions to v3 as v2 uses node12 which has also been deprecated