### PR TITLE
Add reusable Snyk docker image scan action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,49 @@
+name: Reusable Snyk Docker Image Scan
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Label to tag the docker image with"
+        required: true
+        type: string
+    secrets:
+      snyk_token:
+        description: "Snyk service account API token"
+        required: true
+
+jobs:
+  snyk:
+    name: Scan docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build docker image
+        run: |
+          docker build \
+            --tag ${{ inputs.tag }}:scan \
+            --file Dockerfile .
+
+      - name: Scan docker image using Snyk
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.snyk_token }}
+        with:
+          image: ${{ inputs.tag }}:scan
+          args: --file=Dockerfile
+
+      - name: Monitor docker image using Snyk
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.snyk_token }}
+        with:
+          command: monitor
+          image: ${{ inputs.tag }}:scan
+          args: --file=Dockerfile
+
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: snyk.sarif


### PR DESCRIPTION
This adds a reusable GitHub Action that uses Snyk to scan a docker image.

The action takes a `tag` input, and requires a `snyk_token` secret to run.

It uses the `Dockerfile` located in the root folder of the application.

Example usage might look something like this:

```yml
name: Snyk Docker image scan

on:
  schedule:
    - cron: "0 5 * * *"

jobs:
  snyk:
    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/snyk.yml@main
    with:
      tag: "laa-apply-for-legalaid"
    secrets:
      snyk_token: ${{ secrets.SNYK_TOKEN }}
```