### PR TITLE
Add "authenticate to kubernetes cluster" reusable action

### DIFF
--- a/.github/actions/authenticate_to_cluster/action.yml
+++ b/.github/actions/authenticate_to_cluster/action.yml
@@ -1,0 +1,32 @@
+name: "Authenticate to the kubernetes cluster"
+description: 'Authenticate to the kubernetes cluster'
+inputs:
+  kube-cert:
+    description: "Kubernetes cluster authentication certificate"
+    required: true
+  kube-token:
+    description: "Kubernetes cluster authentication token"
+    required: true
+  kube-cluster:
+    description: "Kubernetes cluster name"
+    required: true
+  kube-namespace:
+    description: "Kubernetes cluster namespace"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Authenticate to the cluster
+      shell: bash
+      env:
+        KUBE_CERT: ${{ inputs.kube-cert }}
+        KUBE_TOKEN: ${{ inputs.kube-token }}
+        KUBE_CLUSTER: ${{ inputs.kube-cluster }}
+        KUBE_NAMESPACE: ${{ inputs.kube-namespace }}
+      run: |
+        echo "${KUBE_CERT}" > ca.crt
+        kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+        kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
+        kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+        kubectl config use-context ${KUBE_CLUSTER}

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # LAA Reusable Github Actions
 
-Following the publication of [this article](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) by Github
-announcing the beta release of reusable workflows, this is an attempt to start a central repository 
-of github jobs that can be called from remote repositories.
+Following the publication of [this article](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) by Github announcing the beta release of reusable workflows, this is an attempt to start a central repository of github jobs that can be called from remote repositories.
 
 ## Notices
 This is a beta function from Github and my be changed/break at very short notice
 
-## Currently available actions
-* rubocop
-* rspec
+## Currently available workflows
 * brakeman
+* format
+* rspec
+* rubocop
+* snyk
 
-## Invoking an action
+## Invoking a workflow
 
-In your repo's workflows you can invoke one of these actions with 
+In your repo's workflows you can invoke one of the workflows (available in `.github/workflows/`) with
 ```yaml
 jobs:
   rubocop:
@@ -28,6 +28,44 @@ This can be broken down as follows:
 Where version is the branch name  
 So if you create a branch named `improve-rubocop` you could test the 
 workflow on your remote repo by calling `ministryofjustice/laa-reusable-github-actions/.github/workflows/rubocop.yml@improve-rubocop`
+
+## Currently available actions
+* authenticate_to_cluster
+
+## Invoking an action
+
+In your repo's workflows you can invoke one of the github actions (available in `.github/actions/`) with
+
+```yaml
+# example staging deployment requiring authentication to the kubernetes cluster
+  deploy-staging:
+    runs-on: ubuntu-latest
+    needs: build
+    environment: staging
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Authenticate to cluster
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@main
+        with:
+          kube-cert: ${{ secrets.KUBE_STAGING_CERT }}
+          kube-token: ${{ secrets.KUBE_STAGING_TOKEN }}
+          kube-cluster: ${{ secrets.KUBE_STAGING_CLUSTER }}
+          kube-namespace: ${{ secrets.KUBE_STAGING_NAMESPACE }}
+
+      - name: deployment
+        ...
+
+```
+
+Note that you may want to use the action but pin it so changes to it do not impact your workflow. To achieve this you can use a commit shah after the `@`.
+
+```yaml
+# example using a pinned version of the action for security and stability
+uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@7666443ea3f635ec52544311e0f0ea51830468c0
+```
 
 ### Warning
 

--- a/README.md
+++ b/README.md
@@ -3,34 +3,39 @@
 Following the publication of [this article](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) by Github announcing the beta release of reusable workflows, this is an attempt to start a central repository of github jobs that can be called from remote repositories.
 
 ## Notices
+
 This is a beta function from Github and my be changed/break at very short notice
 
 ## Currently available workflows
-* brakeman
-* format
-* rspec
-* rubocop
-* snyk
+
+- brakeman
+- format
+- rspec
+- rubocop
+- snyk
 
 ## Invoking a workflow
 
 In your repo's workflows you can invoke one of the workflows (available in `.github/workflows/`) with
+
 ```yaml
 jobs:
   rubocop:
     uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/rubocop.yml@main
 ```
+
 This can be broken down as follows:
 
 `ministryofjustice/laa-reusable-github-actions/.github/workflows/rubocop.yml@main`  
 `{---------------- repo_name ----------------}/{-- path to workflow file --}@{version}`
 
 Where version is the branch name  
-So if you create a branch named `improve-rubocop` you could test the 
+So if you create a branch named `improve-rubocop` you could test the
 workflow on your remote repo by calling `ministryofjustice/laa-reusable-github-actions/.github/workflows/rubocop.yml@improve-rubocop`
 
 ## Currently available actions
-* authenticate_to_cluster
+
+- authenticate_to_cluster
 
 ## Invoking an action
 
@@ -69,9 +74,10 @@ uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate
 
 ### Warning
 
-I have set the job name of the initial workflows as `scan` so that, when you use a header 
+I have set the job name of the initial workflows as `scan` so that, when you use a header
 in _your_ repo it will be reflected in the calling path inside your pull request
 So if you have a pull request workflow file in your repo like so:
+
 ```yaml
 name: Pull request
 on: [pull_request]
@@ -87,15 +93,17 @@ jobs:
         image: postgres:10.11
         # <snip>
 ```
+
 Your pull request checks will resemble
+
 ```text
 Pull request / rubocop / scan (pull_request)
 Pull request / something (pull_request)
-``` 
+```
 
-So it doesn't  duplicate the  local job `rubocop` e.g.
+So it doesn't duplicate the local job `rubocop` e.g.
+
 ```text
 Pull request / rubocop / rubocop (pull_request)
 Pull request / something (pull_request)
 ```
-


### PR DESCRIPTION
## What
Adds a resuable action, not workflow, for authenticating to the cloud platform kubernetes cluster.

## Why
This is a common step/action that is required for deployment of applications to the cluster. This [PR for laa-assure-hmrc-data](https://github.com/ministryofjustice/laa-assure-hmrc-data/pull/76) uses it to replace two places it was being used.

