### PR TITLE
Setup Go

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "stable"
+
       - name: Build docker image
         run: |
           docker build \


### PR DESCRIPTION
Update Go to the stable version
Should improve dependency caching
This aim to address the security vulnerable in golang on Apply and Assurance repos
