### PR TITLE
Revert "Setup Go"

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -19,10 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "stable"
-
       - name: Build docker image
         run: |
           docker build \


### PR DESCRIPTION
Reverts ministryofjustice/laa-reusable-github-actions#11

Reverting as this has not resolved the vulnerabilities.
The vuln sits within the third party dependency "esbuild", they have fixed their version of `Go` to v0.0.0

Our version of `Go`  within Docker is > v1.x.x