### PR TITLE
Chore: Update github action versions

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up ruby
         # this should inherit from your .ruby-version
         uses: ruby/setup-ruby@v1
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -11,11 +11,11 @@ jobs:
     name: scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up ruby
         # this should inherit from your .ruby-version
         uses: ruby/setup-ruby@v1
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
A couple of the actions had older checkout and cache versions These are now updated inline with other repos