### PR TITLE
reuseable action using caching to build and push the docker image

### DIFF
--- a/.github/actions/build_and_push_with_cache/action.yml
+++ b/.github/actions/build_and_push_with_cache/action.yml
@@ -1,0 +1,79 @@
+# to call this action, use the following in your workflow file to set up the action:
+
+# - name: Set up Docker Buildx
+#   uses: docker/setup-buildx-action@v3
+#   with:
+#     install: true
+#
+# - name: Cache Docker layers
+#   uses: actions/cache@v3
+#   with:
+#     path: /tmp/.buildx-cache
+#     key: ${{ runner.os }}-buildx-${{ github.sha }}
+#     restore-keys: |
+#       ${{ runner.os }}-buildx-
+#
+# - name: Build and push image with caching
+#   uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build_and_push_with_cache@main
+#   with:
+#     image_registry: ${{ secrets.ECR_REGISTRY_URL }}
+#     image_repo: ${{ vars.ECR_REPOSITORY }}
+#     dockerfile_path: Dockerfile
+#     image_tag: ${{ github.sha }}
+
+
+name: Build and Push Image
+description: Build Image and Push to a Container Registry (with caching)
+
+inputs:
+  image_registry:
+    required: true
+    description: "Image Registry URL"
+  image_repo:
+    required: true
+    description: "Image Repository URL"
+  dockerfile_path:
+    required: true
+    description: "Dockerfile Path"
+    default: "Dockerfile"
+  image_tag:
+    required: true
+    description: "Image Tag"
+    default: ${{ github.sha }}
+
+outputs:
+  image_registry:
+    description: "Image Registry URL"
+    value: ${{ steps.output.outputs.image_registry }}
+  image_repo:
+    description: "Image Repo Path"
+    value: ${{ steps.output.outputs.image_repo }}
+  image_tag:
+    description: "Image Tag"
+    value: ${{ steps.output.outputs.image_tag }}
+  image_uri:
+    description: "Image URI"
+    value: ${{ steps.output.outputs.image_uri }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Docker Build & Push with Cache
+      id: build_and_push
+      run: |
+        docker build \
+          --push \
+          --cache-from=type=local,src=/tmp/.buildx-cache \
+          --cache-to=type=local,dest=/tmp/.buildx-cache \
+          -t ${{ inputs.image_registry }}/${{ inputs.image_repo }}:${{ inputs.image_tag }} \
+          -f ${{ inputs.dockerfile_path }} .
+      shell: bash
+
+    - name: Output
+      id: output
+      run: |
+        echo image_registry=${{ inputs.image_registry }} >> "$GITHUB_OUTPUT"
+        echo image_repo=${{ inputs.image_repo }} >> "$GITHUB_OUTPUT"
+        echo image_tag=${{ inputs.image_tag }} >> "$GITHUB_OUTPUT"
+        echo image_uri="${{ inputs.image_registry }}/${{ inputs.image_repo }}:${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+      shell: bash


### PR DESCRIPTION
This builds on the original build|_and_push job added by Andy Welsh (currently PR in review)

https://github.com/ministryofjustice/laa-reusable-github-actions/blob/3cf3f191e6992812264434a007cda916347ba35e/.github/actions/build-and-push/action.yml

It adds caching so repeated builds are faster.

It does require some extra steps in the workflow that calls the action so I have added those at the top of the action as a comment. I am not sure if this is the best way to handle this, but as it is a composite job I cannot use `uses:` within the action.