### PR TITLE
Bump ruby-setup action 1.231.0 to 1.243.0

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #--v4.2.2
     - name: Set up ruby # this should inherit from your .ruby-version
-      uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 #--1.231.0
+      uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 #--v1.243.0
     - name: Setup Brakeman
       run: |
         gem install brakeman

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #--v4.2.2
     - name: Set up ruby
       # this should inherit from your .ruby-version
-      uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 #--1.231.0
+      uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 #--v1.243.0
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #--4.2.3
       with:
         path: vendor/bundle

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #--v4.2.2
     - name: Set up ruby
       # this should inherit from your .ruby-version
-      uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 #--1.231.0
+      uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 #--v1.243.0
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #--4.2.3
       with:
         path: vendor/bundle


### PR DESCRIPTION
## What
Bump ruby-setup action 1.231.0 to 1.243.0

To pick up latest ruby 3.4.4 version

## Testing
This worked to pick up ruby 3.4.4 when used on a branch of civil apply - [here](https://github.com/ministryofjustice/laa-apply-for-legal-aid/actions/runs/15156354645/job/42612010234?pr=7808)
