### PR TITLE
Fix: Bump the setup ruby version

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #--v4.2.2
     - name: Set up ruby # this should inherit from your .ruby-version
-      uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 #--v1.243.0
+      uses: ruby/setup-ruby@2a7b30092b0caf9c046252510f9273b4875f3db9 #--v1.254.0
     - name: Setup Brakeman
       run: |
         gem install brakeman

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #--v4.2.2
     - name: Set up ruby
       # this should inherit from your .ruby-version
-      uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 #--v1.243.0
+      uses: ruby/setup-ruby@2a7b30092b0caf9c046252510f9273b4875f3db9 #--v1.254.0
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #--4.2.3
       with:
         path: vendor/bundle

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #--v4.2.2
     - name: Set up ruby
       # this should inherit from your .ruby-version
-      uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 #--v1.243.0
+      uses: ruby/setup-ruby@2a7b30092b0caf9c046252510f9273b4875f3db9 #--v1.254.0
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #--4.2.3
       with:
         path: vendor/bundle


### PR DESCRIPTION
This was very out of date and preventing some updates running

This is a manual bump rather than waiting to see if the dependabot auto updates after a week!