### PR TITLE
Add new reusable Security Workflow

### DIFF
--- a/.github/actions/image-scan/action.yml
+++ b/.github/actions/image-scan/action.yml
@@ -3,11 +3,13 @@ description: Detect any known vulnerabilities in a pushed image
 
 inputs:
   image_uri:
-    required: true
+    required: false
     description: "URI of image to scan"
+    default: ""
   snyk_token:
-    required: true
+    required: false
     description: "Generated Token for Snyk"
+    default: ""
   critical_high_exit_code:
     required: true
     description: "Exit code for critical or high scanning, used to override"
@@ -16,97 +18,98 @@ runs:
   using: "composite"
 
   steps:
-  trivy-scan:
-    name: Trivy security scanning
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      security-events: write
-    steps:
-      - name: Scan filesystem for vulnerabilities
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
-        with:
-          scan-type: 'fs'
-          scan-ref: '.'
-          vuln-type: 'os'
-          format: 'sarif'
-          output: 'trivy-fs-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          exit-code: '0'
+    - name: Always run filesystem scan (no image needed)
+      id: filesystem-scan
+      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+      with:
+        scan-type: 'fs'
+        scan-ref: '.'
+        vuln-type: 'os'
+        format: 'sarif'
+        output: 'trivy-fs-results.sarif'
+        severity: 'CRITICAL,HIGH'
+        exit-code: ${{ inputs.critical_high_exit_code }}
 
-      - name: Upload filesystem scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-        if: always()
-        with:
-          sarif_file: 'trivy-fs-results.sarif'
-          category: 'trivy-filesystem'
+    - name: Upload filesystem scan results to GitHub Security
+      if: always()
+      uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+      with:
+        sarif_file: 'trivy-fs-results.sarif'
+        category: 'trivy-filesystem'
 
-      - name: Scan Docker image for vulnerabilities
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'image'
-          image-ref: ${{inputs.image_uri}}
-          format: 'sarif'
-          vuln-type: 'os'
-          output: 'trivy-image-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          exit-code: '0'
+    - name: Always run config scan (no image needed)
+      id: config-scan
+      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+      with:
+        scan-type: 'config'
+        scan-ref: '.'
+        format: 'sarif'
+        vuln-type: 'os'
+        output: 'trivy-config-results.sarif'
+        severity: 'CRITICAL,HIGH'
+        exit-code: ${{ inputs.critical_high_exit_code }}
 
-      - name: Upload Docker image scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-        if: always()
-        with:
-          sarif_file: 'trivy-image-results.sarif'
-          category: 'trivy-image'
+    - name: Upload config scan results to GitHub Security
+      if: always()
+      uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+      with:
+        sarif_file: 'trivy-config-results.sarif'
+        category: 'trivy-config'
 
-      - name: Scan infrastructure configuration for issues
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
-        with:
-          scan-type: 'config'
-          scan-ref: '.'
-          format: 'sarif'
-          vuln-type: 'os'
-          output: 'trivy-config-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          exit-code: '0'
+    - name: Scan Docker image with Trivy
+      if: ${{inputs.image_uri}} != ''
+      id: trivy-image-scan
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: 'image'
+        image-ref: ${{ inputs.image_uri }}
+        format: 'sarif'
+        vuln-type: 'os'
+        output: 'trivy-image-results.sarif'
+        severity: 'CRITICAL,HIGH'
+        exit-code: ${{ inputs.critical_high_exit_code }}
 
-      - name: Upload config scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-        if: always()
-        with:
-          sarif_file: 'trivy-config-results.sarif'
-          category: 'trivy-config'
+    - name: Upload Docker image scan results to GitHub Security
+      if: always() && ${{inputs.image_uri}} != ''
+      uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+      with:
+        sarif_file: 'trivy-image-results.sarif'
+        category: 'trivy-image'
 
-  snyk-scan:
-    name: Snyk security scanning
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      security-events: write
-      contents: read
-    steps:
-      - name: Pull Docker image from ECR for scanning
-        run: docker pull ${{inputs.image_uri}}
+    - name: Run Snyk scans
+      if: ${{inputs.snyk_token}} != '' && ${{inputs.image_uri}} != ''
+      name: Snyk security scanning
+      runs-on: ubuntu-latest
+      permissions:
+        id-token: write
+        security-events: write
+        contents: read
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
 
-      - name: Install Snyk CLI
-        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04
+        - name: Pull Docker image from ECR for scanning
+          run: docker pull ${{ inputs.image_uri }}
 
-      - name: Snyk Code Test
-        continue-on-error: true
-        run: snyk code test --sarif | tee snyk_sarif
-        env:
-          SNYK_TOKEN: ${{ inputs.snyk_token }}
+        - name: Install Snyk CLI
+          uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04
 
-      - name: Upload results to Github Code Scanning
-        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-        with:
-          sarif_file: snyk_sarif
+        - name: Snyk Code Test
+          continue-on-error: true
+          run: snyk code test --sarif | tee snyk_sarif
+          env:
+            SNYK_TOKEN: ${{ inputs.snyk_token }}
 
-      - name: Monitor Docker Vulnerabilities
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ inputs.snyk_token }}
-        with:
-          image: ${{ inputs.image_uri }}
-          command: monitor
+        - name: Upload Snyk Code results to Github Code Scanning
+          if: always()
+          uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+          with:
+            sarif_file: snyk_sarif
+
+        - name: Monitor Docker Vulnerabilities
+          uses: snyk/actions/docker@master
+          env:
+            SNYK_TOKEN: ${{ inputs.snyk_token }}
+          with:
+            image: ${{ inputs.image_uri }}
+            command: monitor

--- a/.github/actions/image-scan/action.yml
+++ b/.github/actions/image-scan/action.yml
@@ -5,6 +5,9 @@ inputs:
   image_uri:
     required: true
     description: "URI of image to scan"
+  snyk_token:
+    required: true
+    description: "Generated Token for Snyk"
   critical_high_exit_code:
     required: true
     description: "Exit code for critical or high scanning, used to override"
@@ -13,27 +16,97 @@ runs:
   using: "composite"
 
   steps:
-  #--Fail on detection of a Critical or High vuln
-  - name: Trivy Scan (Critical and High)
-    uses: aquasecurity/trivy-action@master
-    with:
-      image-ref: ${{ inputs.image_uri }}
-      format: 'table'
-      exit-code: ${{ inputs.critical_high_exit_code }}
-      ignore-unfixed: true
-      vuln-type: 'os,library'
-      severity: 'CRITICAL,HIGH'
+  trivy-scan:
+    name: Trivy security scanning
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      security-events: write
+    steps:
+      - name: Scan filesystem for vulnerabilities
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          vuln-type: 'os'
+          format: 'sarif'
+          output: 'trivy-fs-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
 
-  #--List all other vulns, but do not fail
-  - name: Trivy Image Scan ()
-    uses: aquasecurity/trivy-action@master
-    with:
-      image-ref: ${{ inputs.image_uri }}
-      format: 'table'
-      exit-code: '0'
-      ignore-unfixed: true
-      vuln-type: 'os,library'
-      severity: 'UNKNOWN,LOW,MEDIUM'
-    env:
-      TRIVY_SKIP_DB_UPDATE: true
-      TRIVY_SKIP_JAVA_DB_UPDATE: true
+      - name: Upload filesystem scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        if: always()
+        with:
+          sarif_file: 'trivy-fs-results.sarif'
+          category: 'trivy-filesystem'
+
+      - name: Scan Docker image for vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'image'
+          image-ref: ${{inputs.image_uri}}
+          format: 'sarif'
+          vuln-type: 'os'
+          output: 'trivy-image-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
+
+      - name: Upload Docker image scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        if: always()
+        with:
+          sarif_file: 'trivy-image-results.sarif'
+          category: 'trivy-image'
+
+      - name: Scan infrastructure configuration for issues
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        with:
+          scan-type: 'config'
+          scan-ref: '.'
+          format: 'sarif'
+          vuln-type: 'os'
+          output: 'trivy-config-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
+
+      - name: Upload config scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        if: always()
+        with:
+          sarif_file: 'trivy-config-results.sarif'
+          category: 'trivy-config'
+
+  snyk-scan:
+    name: Snyk security scanning
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      security-events: write
+      contents: read
+    steps:
+      - name: Pull Docker image from ECR for scanning
+        run: docker pull ${{inputs.image_uri}}
+
+      - name: Install Snyk CLI
+        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04
+
+      - name: Snyk Code Test
+        continue-on-error: true
+        run: snyk code test --sarif | tee snyk_sarif
+        env:
+          SNYK_TOKEN: ${{ inputs.snyk_token }}
+
+      - name: Upload results to Github Code Scanning
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        with:
+          sarif_file: snyk_sarif
+
+      - name: Monitor Docker Vulnerabilities
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ inputs.snyk_token }}
+        with:
+          image: ${{ inputs.image_uri }}
+          command: monitor

--- a/.github/actions/image-scan/action.yml
+++ b/.github/actions/image-scan/action.yml
@@ -1,115 +1,156 @@
-name: Scan Image for vulnerabilities
-description: Detect any known vulnerabilities in a pushed image
+name: Reusable Security Scan
 
-inputs:
-  image_uri:
-    required: false
-    description: "URI of image to scan"
-    default: ""
-  snyk_token:
-    required: false
-    description: "Generated Token for Snyk"
-    default: ""
-  critical_high_exit_code:
-    required: true
-    description: "Exit code for critical or high scanning, used to override"
+on:
+  workflow_call:
+    inputs:
+      image_uri:
+        description: "Optional container image URI to scan (e.g. from ECR)"
+        required: false
+        type: string
+      snyk_token:
+        description: "Snyk token (if omitted, Snyk steps are skipped)"
+        required: false
+        type: string
+      semgrep_config:
+        description: "Semgrep ruleset (e.g. 'p/owasp-top-ten')"
+        required: false
+        default: "p/owasp-top-ten"
+        type: string
+    secrets:
+      SNYK_TOKEN:
+        required: false
 
-runs:
-  using: "composite"
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
 
-  steps:
-    - name: Always run filesystem scan (no image needed)
-      id: filesystem-scan
-      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
-      with:
-        scan-type: 'fs'
-        scan-ref: '.'
-        vuln-type: 'os'
-        format: 'sarif'
-        output: 'trivy-fs-results.sarif'
-        severity: 'CRITICAL,HIGH'
-        exit-code: ${{ inputs.critical_high_exit_code }}
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+      id-token: write
 
-    - name: Upload filesystem scan results to GitHub Security
-      if: always()
-      uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-      with:
-        sarif_file: 'trivy-fs-results.sarif'
-        category: 'trivy-filesystem'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
 
-    - name: Always run config scan (no image needed)
-      id: config-scan
-      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
-      with:
-        scan-type: 'config'
-        scan-ref: '.'
-        format: 'sarif'
-        vuln-type: 'os'
-        output: 'trivy-config-results.sarif'
-        severity: 'CRITICAL,HIGH'
-        exit-code: ${{ inputs.critical_high_exit_code }}
+      ########################################################
+      # 1. TRIVY – FS + CONFIG + (optional) IMAGE
+      ########################################################
 
-    - name: Upload config scan results to GitHub Security
-      if: always()
-      uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-      with:
-        sarif_file: 'trivy-config-results.sarif'
-        category: 'trivy-config'
+      - name: Trivy FS scan
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        with:
+          scan-type: fs
+          scan-ref: .
+          vuln-type: 'os,library'
+          format: sarif
+          output: trivy-fs.sarif
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '0'
 
-    - name: Scan Docker image with Trivy
-      if: ${{inputs.image_uri}} != ''
-      id: trivy-image-scan
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: 'image'
-        image-ref: ${{ inputs.image_uri }}
-        format: 'sarif'
-        vuln-type: 'os'
-        output: 'trivy-image-results.sarif'
-        severity: 'CRITICAL,HIGH'
-        exit-code: ${{ inputs.critical_high_exit_code }}
+      - name: Upload Trivy FS SARIF
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        if: always()
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
 
-    - name: Upload Docker image scan results to GitHub Security
-      if: always() && ${{inputs.image_uri}} != ''
-      uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-      with:
-        sarif_file: 'trivy-image-results.sarif'
-        category: 'trivy-image'
+      - name: Trivy config scan
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        with:
+          scan-type: config
+          scan-ref: .
+          format: sarif
+          output: trivy-config.sarif
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '0'
 
-    - name: Run Snyk scans
-      if: ${{inputs.snyk_token}} != '' && ${{inputs.image_uri}} != ''
-      name: Snyk security scanning
-      runs-on: ubuntu-latest
-      permissions:
-        id-token: write
-        security-events: write
-        contents: read
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
+      - name: Upload Trivy config SARIF
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        if: always()
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config
 
-        - name: Pull Docker image from ECR for scanning
-          run: docker pull ${{ inputs.image_uri }}
+      - name: Trivy image scan (optional)
+        if: inputs.image_uri != ''
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        with:
+          scan-type: image
+          image-ref: ${{ inputs.image_uri }}
+          vuln-type: 'os,library'
+          format: sarif
+          output: trivy-image.sarif
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '0'
 
-        - name: Install Snyk CLI
-          uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04
+      - name: Upload Trivy image SARIF
+        if: always() && inputs.image_uri != ''
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image
 
-        - name: Snyk Code Test
-          continue-on-error: true
-          run: snyk code test --sarif | tee snyk_sarif
-          env:
-            SNYK_TOKEN: ${{ inputs.snyk_token }}
+      ########################################################
+      # 2. SNYK – CODE + (optional) CONTAINER
+      ########################################################
 
-        - name: Upload Snyk Code results to Github Code Scanning
-          if: always()
-          uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-          with:
-            sarif_file: snyk_sarif
+      - name: Setup Snyk
+        if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        uses: snyk/actions/setup@v4
 
-        - name: Monitor Docker Vulnerabilities
-          uses: snyk/actions/docker@master
-          env:
-            SNYK_TOKEN: ${{ inputs.snyk_token }}
-          with:
-            image: ${{ inputs.image_uri }}
-            command: monitor
+      - name: Snyk Code test
+        if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        run: snyk code test --sarif > snyk-code.sarif || true
+        env:
+          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token || secrets.SNYK_TOKEN }}
+
+      - name: Upload Snyk Code SARIF
+        if: always() && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        with:
+          sarif_file: snyk-code.sarif
+          category: snyk-code
+
+      - name: Snyk container test (optional, requires image_uri)
+        if: (inputs.image_uri != '') && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        run: snyk container test ${{ inputs.image_uri }} --sarif-file-output=snyk-container.sarif || true
+        env:
+          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token || secrets.SNYK_TOKEN }}
+
+      - name: Upload Snyk container SARIF
+        if: always() && (inputs.image_uri != '') && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        with:
+          sarif_file: snyk-container.sarif
+          category: snyk-container
+
+      ########################################################
+      # 3. SEMGREP – SAST
+      ########################################################
+
+      - name: Setup Python for Semgrep
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
+        with:
+          python-version: '3.x'
+
+      - name: Install Semgrep
+        run: |
+          python -m pip install --upgrade pip
+          pip install semgrep
+
+      - name: Run Semgrep SAST
+        run: |
+          semgrep \
+            --config "${{ inputs.semgrep_config }}" \
+            --sarif \
+            --error \
+            --output semgrep.sarif || true
+
+      - name: Upload Semgrep SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep

--- a/.github/actions/image-scan/action.yml
+++ b/.github/actions/image-scan/action.yml
@@ -1,156 +1,39 @@
-name: Reusable Security Scan
+name: Scan Image for vulnerabilities
+description: Detect any known vulnerabilities in a pushed image
 
-on:
-  workflow_call:
-    inputs:
-      image_uri:
-        description: "Optional container image URI to scan (e.g. from ECR)"
-        required: false
-        type: string
-      snyk_token:
-        description: "Snyk token (if omitted, Snyk steps are skipped)"
-        required: false
-        type: string
-      semgrep_config:
-        description: "Semgrep ruleset (e.g. 'p/owasp-top-ten')"
-        required: false
-        default: "p/owasp-top-ten"
-        type: string
-    secrets:
-      SNYK_TOKEN:
-        required: false
+inputs:
+  image_uri:
+    required: true
+    description: "URI of image to scan"
+  critical_high_exit_code:
+    required: true
+    description: "Exit code for critical or high scanning, used to override"
 
-jobs:
-  security-scan:
-    runs-on: ubuntu-latest
+runs:
+  using: "composite"
 
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-      id-token: write
+  steps:
+  #--Fail on detection of a Critical or High vuln
+  - name: Trivy Scan (Critical and High)
+    uses: aquasecurity/trivy-action@master
+    with:
+      image-ref: ${{ inputs.image_uri }}
+      format: 'table'
+      exit-code: ${{ inputs.critical_high_exit_code }}
+      ignore-unfixed: true
+      vuln-type: 'os,library'
+      severity: 'CRITICAL,HIGH'
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
-
-      ########################################################
-      # 1. TRIVY – FS + CONFIG + (optional) IMAGE
-      ########################################################
-
-      - name: Trivy FS scan
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
-        with:
-          scan-type: fs
-          scan-ref: .
-          vuln-type: 'os,library'
-          format: sarif
-          output: trivy-fs.sarif
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          exit-code: '0'
-
-      - name: Upload Trivy FS SARIF
-        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-        if: always()
-        with:
-          sarif_file: trivy-fs.sarif
-          category: trivy-fs
-
-      - name: Trivy config scan
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
-        with:
-          scan-type: config
-          scan-ref: .
-          format: sarif
-          output: trivy-config.sarif
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          exit-code: '0'
-
-      - name: Upload Trivy config SARIF
-        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-        if: always()
-        with:
-          sarif_file: trivy-config.sarif
-          category: trivy-config
-
-      - name: Trivy image scan (optional)
-        if: inputs.image_uri != ''
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
-        with:
-          scan-type: image
-          image-ref: ${{ inputs.image_uri }}
-          vuln-type: 'os,library'
-          format: sarif
-          output: trivy-image.sarif
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          exit-code: '0'
-
-      - name: Upload Trivy image SARIF
-        if: always() && inputs.image_uri != ''
-        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-        with:
-          sarif_file: trivy-image.sarif
-          category: trivy-image
-
-      ########################################################
-      # 2. SNYK – CODE + (optional) CONTAINER
-      ########################################################
-
-      - name: Setup Snyk
-        if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
-        uses: snyk/actions/setup@v4
-
-      - name: Snyk Code test
-        if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
-        run: snyk code test --sarif > snyk-code.sarif || true
-        env:
-          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token || secrets.SNYK_TOKEN }}
-
-      - name: Upload Snyk Code SARIF
-        if: always() && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
-        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-        with:
-          sarif_file: snyk-code.sarif
-          category: snyk-code
-
-      - name: Snyk container test (optional, requires image_uri)
-        if: (inputs.image_uri != '') && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
-        run: snyk container test ${{ inputs.image_uri }} --sarif-file-output=snyk-container.sarif || true
-        env:
-          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token || secrets.SNYK_TOKEN }}
-
-      - name: Upload Snyk container SARIF
-        if: always() && (inputs.image_uri != '') && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
-        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-        with:
-          sarif_file: snyk-container.sarif
-          category: snyk-container
-
-      ########################################################
-      # 3. SEMGREP – SAST
-      ########################################################
-
-      - name: Setup Python for Semgrep
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
-        with:
-          python-version: '3.x'
-
-      - name: Install Semgrep
-        run: |
-          python -m pip install --upgrade pip
-          pip install semgrep
-
-      - name: Run Semgrep SAST
-        run: |
-          semgrep \
-            --config "${{ inputs.semgrep_config }}" \
-            --sarif \
-            --error \
-            --output semgrep.sarif || true
-
-      - name: Upload Semgrep SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
-        with:
-          sarif_file: semgrep.sarif
-          category: semgrep
+  #--List all other vulns, but do not fail
+  - name: Trivy Image Scan ()
+    uses: aquasecurity/trivy-action@master
+    with:
+      image-ref: ${{ inputs.image_uri }}
+      format: 'table'
+      exit-code: '0'
+      ignore-unfixed: true
+      vuln-type: 'os,library'
+      severity: 'UNKNOWN,LOW,MEDIUM'
+    env:
+      TRIVY_SKIP_DB_UPDATE: true
+      TRIVY_SKIP_JAVA_DB_UPDATE: true

--- a/.github/actions/test.yml
+++ b/.github/actions/test.yml
@@ -1,8 +1,0 @@
-name: Security scan
-
-on:
-  push:
-
-jobs:
-  security:
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/reusable-security-scan.yml@security-pipeline-actions

--- a/.github/actions/test.yml
+++ b/.github/actions/test.yml
@@ -1,0 +1,8 @@
+name: Security scan
+
+on:
+  push:
+
+jobs:
+  security:
+    uses: ministryofjustice/laa-reusable-github-actions/.github/actions/image-scan/actions.yml@security-pipeline-actions

--- a/.github/actions/test.yml
+++ b/.github/actions/test.yml
@@ -1,0 +1,8 @@
+name: Security scan
+
+on:
+  push:
+
+jobs:
+  security:
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/reusable-security-scan.yml@security-pipeline-actions

--- a/.github/actions/test.yml
+++ b/.github/actions/test.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   security:
-    uses: ministryofjustice/laa-reusable-github-actions/.github/actions/image-scan/actions.yml@security-pipeline-actions
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/reusable-security-scan.yml@security-pipeline-actions

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -103,7 +103,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload Snyk Code SARIF
-        if: always() && secrets.SNYK_TOKEN
+        if: always() && secrets.SNYK_TOKEN != ''
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
           sarif_file: snyk-code.sarif

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -93,30 +93,30 @@ jobs:
       ########################################################
 
       - name: Setup Snyk
-        if: ${{secrets.SNYK_TOKEN}} != ''
+        if: secrets.SNYK_TOKEN != ''
         uses: snyk/actions/setup@v4
 
       - name: Snyk Code test
-        if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        if: secrets.SNYK_TOKEN != ''
         run: snyk code test --sarif > snyk-code.sarif || true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload Snyk Code SARIF
-        if: always() && ${{secrets.SNYK_TOKEN}}
+        if: always() && secrets.SNYK_TOKEN
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
           sarif_file: snyk-code.sarif
           category: snyk-code
 
       - name: Snyk container test (optional, requires image_uri)
-        if: (inputs.image_uri != '') && ${{secrets.SNYK_TOKEN}} != ''
+        if: (inputs.image_uri != '') && secrets.SNYK_TOKEN != ''
         run: snyk container test ${{ inputs.image_uri }} --sarif-file-output=snyk-container.sarif || true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload Snyk container SARIF
-        if: always() && (inputs.image_uri != '') && ${{secrets.SNYK_TOKEN}} != ''
+        if: always() && (inputs.image_uri != '') && secrets.SNYK_TOKEN != ''
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
           sarif_file: snyk-container.sarif

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -16,9 +16,6 @@ on:
         required: false
         default: "p/owasp-top-ten"
         type: string
-    secrets:
-      SNYK_TOKEN:
-        required: false
 
 jobs:
   security-scan:
@@ -97,30 +94,30 @@ jobs:
       ########################################################
 
       - name: Setup Snyk
-        if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        if: (inputs.snyk_token != '')
         uses: snyk/actions/setup@v4
 
       - name: Snyk Code test
-        if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        if: (inputs.snyk_token != '')
         run: snyk code test --sarif > snyk-code.sarif || true
         env:
-          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token || secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token }}
 
       - name: Upload Snyk Code SARIF
-        if: always() && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        if: always() && (inputs.snyk_token != '')
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
           sarif_file: snyk-code.sarif
           category: snyk-code
 
       - name: Snyk container test (optional, requires image_uri)
-        if: (inputs.image_uri != '') && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        if: (inputs.image_uri != '') && (inputs.snyk_token != '')
         run: snyk container test ${{ inputs.image_uri }} --sarif-file-output=snyk-container.sarif || true
         env:
-          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token || secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token}}
 
       - name: Upload Snyk container SARIF
-        if: always() && (inputs.image_uri != '') && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        if: always() && (inputs.image_uri != '') && (inputs.snyk_token != '')
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
           sarif_file: snyk-container.sarif

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -129,10 +129,9 @@ jobs:
 
       - name: Install OpenGrep binary
         run: |
-          wget -q https://github.com/opengrep/opengrep/releases/download/v1.12.1/opengrep-core_linux_x86.tar.gz
-          tar -xzf opengrep-core_linux_x86.tar.gz
-          chmod +x opengrep-core_linux_x86
-          sudo mv opengrep-core_linux_x86 /usr/local/bin/opengrep
+          wget -q https://github.com/opengrep/opengrep/releases/download/v1.12.1/opengrep_manylinux_x86 -O opengrep
+          chmod +x opengrep
+          sudo mv opengrep /usr/local/bin/opengrep
           opengrep --version
 
       - name: Run OpenGrep SAST

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -14,7 +14,7 @@ on:
         type: string
     secrets:
       SNYK_TOKEN:
-        required: false
+        required: true
 
 jobs:
   security-scan:
@@ -93,30 +93,29 @@ jobs:
       ########################################################
 
       - name: Setup Snyk
-        if: secrets.SNYK_TOKEN != ''
-        uses: snyk/actions/setup@v4
+        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04
 
       - name: Snyk Code test
-        if: secrets.SNYK_TOKEN != ''
-        run: snyk code test --sarif > snyk-code.sarif || true
+        run: 
+            if [ -n "$SNYK_TOKEN" ]; then
+              snyk code test --sarif > snyk-code.sarif || true
+            fi
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload Snyk Code SARIF
-        if: always() && secrets.SNYK_TOKEN != ''
+        if: success()
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
           sarif_file: snyk-code.sarif
           category: snyk-code
 
       - name: Snyk container test (optional, requires image_uri)
-        if: (inputs.image_uri != '') && secrets.SNYK_TOKEN != ''
         run: snyk container test ${{ inputs.image_uri }} --sarif-file-output=snyk-container.sarif || true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload Snyk container SARIF
-        if: always() && (inputs.image_uri != '') && secrets.SNYK_TOKEN != ''
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
           sarif_file: snyk-container.sarif

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -96,7 +96,7 @@ jobs:
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04
 
       - name: Snyk Code test
-        run: 
+        run: |
             if [ -n "$SNYK_TOKEN" ]; then
               snyk code test --sarif > snyk-code.sarif || true
             fi

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -127,16 +127,12 @@ jobs:
       # 3. OPENGREP – SAST
       ########################################################
 
-      - name: Setup Python for Semgrep
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
-        with:
-          python-version: '3.x'
-
-
-      - name: Install OpenGrep
+      - name: Install OpenGrep binary
         run: |
-          python -m pip install --upgrade pip
-          pip install opengrep
+          # Download latest OpenGrep binary for Linux x86_64
+          curl -fsSL https://github.com/opengrep/opengrep/releases/latest/download/opengrep_manylinux_x86_64 -o /usr/local/bin/opengrep
+          chmod +x /usr/local/bin/opengrep
+          opengrep --version
 
       - name: Run OpenGrep SAST
         run: |

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -1,0 +1,156 @@
+name: Reusable Security Scan
+
+on:
+  workflow_call:
+    inputs:
+      image_uri:
+        description: "Optional container image URI to scan (e.g. from ECR)"
+        required: false
+        type: string
+      snyk_token:
+        description: "Snyk token (if omitted, Snyk steps are skipped)"
+        required: false
+        type: string
+      semgrep_config:
+        description: "Semgrep ruleset (e.g. 'p/owasp-top-ten')"
+        required: false
+        default: "p/owasp-top-ten"
+        type: string
+    secrets:
+      SNYK_TOKEN:
+        required: false
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+
+      ########################################################
+      # 1. TRIVY – FS + CONFIG + (optional) IMAGE
+      ########################################################
+
+      - name: Trivy FS scan
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        with:
+          scan-type: fs
+          scan-ref: .
+          vuln-type: 'os,library'
+          format: sarif
+          output: trivy-fs.sarif
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '0'
+
+      - name: Upload Trivy FS SARIF
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        if: always()
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+      - name: Trivy config scan
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        with:
+          scan-type: config
+          scan-ref: .
+          format: sarif
+          output: trivy-config.sarif
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '0'
+
+      - name: Upload Trivy config SARIF
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        if: always()
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config
+
+      - name: Trivy image scan (optional)
+        if: inputs.image_uri != ''
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        with:
+          scan-type: image
+          image-ref: ${{ inputs.image_uri }}
+          vuln-type: 'os,library'
+          format: sarif
+          output: trivy-image.sarif
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '0'
+
+      - name: Upload Trivy image SARIF
+        if: always() && inputs.image_uri != ''
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image
+
+      ########################################################
+      # 2. SNYK – CODE + (optional) CONTAINER
+      ########################################################
+
+      - name: Setup Snyk
+        if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        uses: snyk/actions/setup@v4
+
+      - name: Snyk Code test
+        if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        run: snyk code test --sarif > snyk-code.sarif || true
+        env:
+          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token || secrets.SNYK_TOKEN }}
+
+      - name: Upload Snyk Code SARIF
+        if: always() && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        with:
+          sarif_file: snyk-code.sarif
+          category: snyk-code
+
+      - name: Snyk container test (optional, requires image_uri)
+        if: (inputs.image_uri != '') && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        run: snyk container test ${{ inputs.image_uri }} --sarif-file-output=snyk-container.sarif || true
+        env:
+          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token || secrets.SNYK_TOKEN }}
+
+      - name: Upload Snyk container SARIF
+        if: always() && (inputs.image_uri != '') && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        with:
+          sarif_file: snyk-container.sarif
+          category: snyk-container
+
+      ########################################################
+      # 3. SEMGREP – SAST
+      ########################################################
+
+      - name: Setup Python for Semgrep
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
+        with:
+          python-version: '3.x'
+
+      - name: Install Semgrep
+        run: |
+          python -m pip install --upgrade pip
+          pip install semgrep
+
+      - name: Run Semgrep SAST
+        run: |
+          semgrep \
+            --config "${{ inputs.semgrep_config }}" \
+            --sarif \
+            --error \
+            --output semgrep.sarif || true
+
+      - name: Upload Semgrep SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -129,10 +129,10 @@ jobs:
 
       - name: Install OpenGrep binary
         run: |
-          # Download latest OpenGrep binary for Linux x86_64
-          curl -fsSL https://github.com/opengrep/opengrep/releases/latest/download/opengrep_manylinux_x86_64 -o /usr/local/bin/opengrep
-          chmod +x /usr/local/bin/opengrep
-          opengrep --version
+            wget -q https://github.com/opengrep/opengrep/releases/download/v1.12.1/opengrep_manylinux_x86_64 -O opengrep
+            chmod +x opengrep
+            sudo mv opengrep /usr/local/bin/opengrep
+            opengrep --version
 
       - name: Run OpenGrep SAST
         run: |

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -7,10 +7,6 @@ on:
         description: "Optional container image URI to scan (e.g. from ECR)"
         required: false
         type: string
-      snyk_token:
-        description: "Snyk token (if omitted, Snyk steps are skipped)"
-        required: false
-        type: string
       semgrep_config:
         description: "Semgrep ruleset (e.g. 'p/owasp-top-ten')"
         required: false
@@ -97,30 +93,30 @@ jobs:
       ########################################################
 
       - name: Setup Snyk
-        if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        if: ${{secrets.SNYK_TOKEN}} != ''
         uses: snyk/actions/setup@v4
 
       - name: Snyk Code test
         if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
         run: snyk code test --sarif > snyk-code.sarif || true
         env:
-          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token || secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload Snyk Code SARIF
-        if: always() && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        if: always() && ${{secrets.SNYK_TOKEN}}
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
           sarif_file: snyk-code.sarif
           category: snyk-code
 
       - name: Snyk container test (optional, requires image_uri)
-        if: (inputs.image_uri != '') && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        if: (inputs.image_uri != '') && ${{secrets.SNYK_TOKEN}} != ''
         run: snyk container test ${{ inputs.image_uri }} --sarif-file-output=snyk-container.sarif || true
         env:
-          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token || secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload Snyk container SARIF
-        if: always() && (inputs.image_uri != '') && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
+        if: always() && (inputs.image_uri != '') && ${{secrets.SNYK_TOKEN}} != ''
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
           sarif_file: snyk-container.sarif

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -111,11 +111,13 @@ jobs:
           category: snyk-code
 
       - name: Snyk container test (optional, requires image_uri)
+        if: inputs.image_uri != ''
         run: snyk container test ${{ inputs.image_uri }} --sarif-file-output=snyk-container.sarif || true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload Snyk container SARIF
+        if: always() && inputs.image_uri != ''
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
           sarif_file: snyk-container.sarif

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -129,10 +129,11 @@ jobs:
 
       - name: Install OpenGrep binary
         run: |
-            wget -q https://github.com/opengrep/opengrep/releases/download/v1.12.1/opengrep_manylinux_x86_64 -O opengrep
-            chmod +x opengrep
-            sudo mv opengrep /usr/local/bin/opengrep
-            opengrep --version
+          wget -q https://github.com/opengrep/opengrep/releases/download/v1.12.1/opengrep-core_linux_x86.tar.gz
+          tar -xzf opengrep-core_linux_x86.tar.gz
+          chmod +x opengrep-core_linux_x86
+          sudo mv opengrep-core_linux_x86 /usr/local/bin/opengrep
+          opengrep --version
 
       - name: Run OpenGrep SAST
         run: |

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -7,8 +7,8 @@ on:
         description: "Optional container image URI to scan (e.g. from ECR)"
         required: false
         type: string
-      semgrep_config:
-        description: "Semgrep ruleset (e.g. 'p/owasp-top-ten')"
+      opengrep_config:
+        description: "Opengrep ruleset (e.g. 'p/owasp-top-ten')"
         required: false
         default: "p/owasp-top-ten"
         type: string
@@ -124,7 +124,7 @@ jobs:
           category: snyk-container
 
       ########################################################
-      # 3. SEMGREP – SAST
+      # 3. OPENGREP – SAST
       ########################################################
 
       - name: Setup Python for Semgrep
@@ -132,22 +132,23 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install Semgrep
+
+      - name: Install OpenGrep
         run: |
           python -m pip install --upgrade pip
-          pip install semgrep
+          pip install opengrep
 
-      - name: Run Semgrep SAST
+      - name: Run OpenGrep SAST
         run: |
-          semgrep \
-            --config "${{ inputs.semgrep_config }}" \
+          opengrep \
+            --config "${{ inputs.opengrep_config }}" \
             --sarif \
             --error \
-            --output semgrep.sarif || true
+            --output opengrep.sarif || true
 
-      - name: Upload Semgrep SARIF
+      - name: Upload OpenGrep SARIF
         if: always()
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
-          sarif_file: semgrep.sarif
-          category: semgrep
+          sarif_file: opengrep.sarif
+          category: opengrep

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -127,7 +127,15 @@ jobs:
       # 3. OPENGREP – SAST
       ########################################################
 
+      - name: Cache OpenGrep binary
+        id: cache-opengrep
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: /usr/local/bin/opengrep
+          key: opengrep-v1.12.1-${{ runner.os }}
+
       - name: Install OpenGrep binary
+        if: steps.cache-opengrep.outputs.cache-hit != 'true'
         run: |
           wget -q https://github.com/opengrep/opengrep/releases/download/v1.12.1/opengrep_manylinux_x86 -O opengrep
           chmod +x opengrep

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -16,6 +16,9 @@ on:
         required: false
         default: "p/owasp-top-ten"
         type: string
+    secrets:
+      SNYK_TOKEN:
+        required: false
 
 jobs:
   security-scan:
@@ -94,30 +97,30 @@ jobs:
       ########################################################
 
       - name: Setup Snyk
-        if: (inputs.snyk_token != '')
+        if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
         uses: snyk/actions/setup@v4
 
       - name: Snyk Code test
-        if: (inputs.snyk_token != '')
+        if: (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
         run: snyk code test --sarif > snyk-code.sarif || true
         env:
-          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token }}
+          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token || secrets.SNYK_TOKEN }}
 
       - name: Upload Snyk Code SARIF
-        if: always() && (inputs.snyk_token != '')
+        if: always() && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
           sarif_file: snyk-code.sarif
           category: snyk-code
 
       - name: Snyk container test (optional, requires image_uri)
-        if: (inputs.image_uri != '') && (inputs.snyk_token != '')
+        if: (inputs.image_uri != '') && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
         run: snyk container test ${{ inputs.image_uri }} --sarif-file-output=snyk-container.sarif || true
         env:
-          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token}}
+          SNYK_TOKEN: ${{ inputs.snyk_token != '' && inputs.snyk_token || secrets.SNYK_TOKEN }}
 
       - name: Upload Snyk container SARIF
-        if: always() && (inputs.image_uri != '') && (inputs.snyk_token != '')
+        if: always() && (inputs.image_uri != '') && (inputs.snyk_token != '' || secrets.SNYK_TOKEN != '')
         uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7
         with:
           sarif_file: snyk-container.sarif


### PR DESCRIPTION
Adds in a reusable security workflow that can be used via
name: Security scan

on:
  push:

jobs:
  security:
    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/reusable-security-scan.yml@security-pipeline-actions
    inputs:
      image_uri: 'test'
    secrets:
      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
      
 
The workflow uses snyk, trivy and opengrep to SAST scan the current repo along with images provided.