### PR TITLE
Updated cp-build-push with sast workflow

### DIFF
--- a/.github/workflows/cp-build-push.yml
+++ b/.github/workflows/cp-build-push.yml
@@ -21,10 +21,6 @@ on:
         required: false
         type: string
         default: ${{ github.sha }}
-      image_scan_critical_high_exit_code:
-        description: "Error code for image scanner critical/high vulns" #--Set to 0 to allow soft failures
-        type: number
-        default: 1
     outputs:
       image_registry:
         description: "Image Registry"
@@ -38,6 +34,13 @@ on:
       image_uri:
         description: "Image Registry"
         value: ${{ jobs.build_push.outputs.image_uri }}
+    secrets:
+      SNYK_CLIENT_ID:
+        required: true
+      SNYK_CLIENT_SECRET:
+        required: true
+      ECR_ROLE_TO_ASSUME:
+        required: true
 
 jobs:
   build_push:
@@ -76,15 +79,20 @@ jobs:
         echo image_tag=${{ steps.build.outputs.image_tag }} >> "$GITHUB_OUTPUT"
         echo image_uri="${{ steps.build.outputs.image_registry }}/${{ steps.build.outputs.image_repo }}:${{ steps.build.outputs.image_tag }}" >> "$GITHUB_OUTPUT"
 
-    - name: Image Scan
-      id: scan-post
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/image-scan@main
-      with:
-        image_uri: ${{ steps.output.outputs.image_uri }}
-        critical_high_exit_code: ${{ inputs.image_scan_critical_high_exit_code }}
-
     outputs:
       image_registry: ${{ steps.output.outputs.image_registry }}
       image_repo: ${{ steps.output.outputs.image_repo }}
       image_tag: ${{ steps.output.outputs.image_tag }}
       image_uri: ${{ steps.output.outputs.image_uri }}
+
+  scan:
+    needs: build_push
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/sast.yml@main
+    with:
+      image_uri: ${{ needs.build_push.outputs.image_uri }}
+      dockerfile_path: ${{ inputs.dockerfile_path }}
+      ecr_session_name: "github-cicd-${{ inputs.app_name }}-scan-${{ github.run_number }}"
+    secrets:
+      SNYK_CLIENT_ID: ${{ secrets.SNYK_CLIENT_ID }}
+      SNYK_CLIENT_SECRET: ${{ secrets.SNYK_CLIENT_SECRET }}
+      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}

--- a/docs/README-cp-build-push-deploy.md
+++ b/docs/README-cp-build-push-deploy.md
@@ -6,16 +6,22 @@ Build and push and Image to the Cloud Platform and then deploy it using using th
 
 ### Variables
 
-| Secret     | Meaning    |
-| ---------- | ---------- |
-| AWS_REGION | AWS Region |
+| Variable       | Meaning        |
+| -------------- | -------------- |
+| ECR_REGION     | AWS Region     |
+| ECR_REPOSITORY | ECR Repository |
 
 ### Secrets
 
-| Secret                | Meaning                                                    |
-| --------------------- | ---------------------------------------------------------- |
-| DEPLOYMENT_ACCOUNT_ID | AWS Account ID for the account being authenticated against |
-| ECR_ACCOUNT_ID        | AWS Account ID containing the ECR Repo being pushed to     |
+| Secret             | Meaning                                               |
+| ------------------ | ----------------------------------------------------- |
+| ECR_ROLE_TO_ASSUME | AWS IAM Role to assume during pipeline authentication |
+| SNYK_CLIENT_ID     | Snyk OAuth client ID for SAST and image scanning      |
+| SNYK_CLIENT_SECRET | Snyk OAuth client secret for SAST and image scanning  |
+| KUBE_CLUSTER       | Kubernetes cluster endpoint                           |
+| KUBE_NAMESPACE     | Kubernetes namespace to deploy to                     |
+| KUBE_TOKEN         | Kubernetes service account token                      |
+| KUBE_CERT          | Kubernetes cluster certificate authority              |
 
 ## Example Usage
 
@@ -32,8 +38,10 @@ jobs:
     uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/cp-build-push-deploy.yml@main
     with:
       environment: dev #--Requires multiple Github Environments set up in CP
+      app_name: my-app
       image_tag: ${{ github.event.release.tag_name }}
       helm_release_name: my-release-name
+      helm_chart: ./laa-generic-helm-chart
       helm_values_path: ./helm/values.yaml
       k8s_service_account: cd-serviceaccount #--Requires CD service account created by CP
     secrets: inherit

--- a/docs/README-cp-build-push.md
+++ b/docs/README-cp-build-push.md
@@ -1,23 +1,27 @@
 # cp-build-push Github Actions Workflow
 
-Build and push an image to the Cloud Platform
+Build and push an image to the Cloud Platform, then run [sast workflow](./README-sast.md) and image vulnerability scanning via Snyk.
 
 ## Required Repo Environment Variables/Secrets:
 
 ### Variables
 
-The variables and secrets below are mandatory, but all are injected in to the environment automatically by the CP as part of repository configuration, they should not be created manually. See [here](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/create.html) for details.
+The variables below are mandatory, and are all are injected into the environment automatically by the CP as part of repository configuration, they should not be created manually. See [here](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/create.html) for details.
 
-| Secret         | Meaning                   |
-| -------------- | ------------------------- |
-| ECR_REGION     | AWS Region                |
-| ECR_REPOSITORY | ECR Repository to Push to |
+| Variable       | Meaning        |
+| -------------- | -------------- |
+| ECR_REGION     | AWS Region     |
+| ECR_REPOSITORY | ECR Repository |
 
 ### Secrets
+
+The secrets below are mandatory `ECR_ROLE_TO_ASSUME` is injected into the environment automatically by the CP, see above.
 
 | Secret             | Meaning                                               |
 | ------------------ | ----------------------------------------------------- |
 | ECR_ROLE_TO_ASSUME | AWS IAM Role to assume during pipeline authentication |
+| SNYK_CLIENT_ID     | Snyk OAuth client ID for SAST and image scanning      |
+| SNYK_CLIENT_SECRET | Snyk OAuth client secret for SAST and image scanning  |
 
 ## Example Usage
 
@@ -31,7 +35,7 @@ on:
 
 jobs:
   build_and_push:
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/mp-build-push.yml@main
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/cp-build-push.yml@main
     secrets: inherit
     with:
       app_name: my-app
@@ -50,7 +54,7 @@ on:
 
 jobs:
   build_and_push:
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/mp-build-push.yml@main
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/cp-build-push.yml@main
     secrets: inherit
     with:
       app_name: my-app

--- a/docs/README-cp-deploy.md
+++ b/docs/README-cp-deploy.md
@@ -4,18 +4,14 @@ Deploy an application to the Cloud Platform using the laa-generic-service Helm C
 
 ## Required Repo Environment Variables/Secrets:
 
-### Variables
-
-| Secret     | Meaning    |
-| ---------- | ---------- |
-| AWS_REGION | AWS Region |
-
 ### Secrets
 
-| Secret                | Meaning                                                    |
-| --------------------- | ---------------------------------------------------------- |
-| DEPLOYMENT_ACCOUNT_ID | AWS Account ID for the account being authenticated against |
-| ECR_ACCOUNT_ID        | AWS Account ID containing the ECR Repo being pushed to     |
+| Secret         | Meaning                                  |
+| -------------- | ---------------------------------------- |
+| KUBE_CLUSTER   | Kubernetes cluster endpoint              |
+| KUBE_NAMESPACE | Kubernetes namespace to deploy to        |
+| KUBE_TOKEN     | Kubernetes service account token         |
+| KUBE_CERT      | Kubernetes cluster certificate authority |
 
 ## Example Usage
 
@@ -40,6 +36,7 @@ jobs:
       image_tag: 0.0.1
       k8s_service_account: cd-serviceaccount #--Requires CD service account created by CP
       helm_release_name: my-release-name
+      helm_chart: ./laa-generic-helm-chart
       helm_values_path: ./helm/values.yaml
     secrets: inherit
 ```
@@ -56,7 +53,7 @@ on:
 
 jobs:
   build_and_push:
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/mp-build-push.yml@main
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/cp-build-push.yml@main
     secrets: inherit
     with:
       app_name: my-app
@@ -71,6 +68,7 @@ jobs:
       image_tag: ${{ needs.build_and_push.outputs.image_tag }}
       k8s_service_account: cd-serviceaccount #--Requires CD service account created by CP
       helm_release_name: my-release-name
+      helm_chart: ./laa-generic-helm-chart
       helm_values_path: ./helm/values.yaml
     secrets: inherit
 ```


### PR DESCRIPTION
Since the image-scan action was updated to remove trivy and use snyk and converted to reusable workflow, the the cp-build-push.yml workflow has been broken given errors "Unrecognized named-values".

Following the image-scan readme stating this action should be treated as deprecated,  i have updated the workflow to use sast.yml

i have opted to specify only use SNYK_CLIENT_ID and SNYK_CLIENT_SECRET and exclude SNYK_TOKEN to force snyk OAuth authentication 

Also updated the readme's