### PR TITLE
Add octo-sts step to acquire token

### DIFF
--- a/.github/workflows/cp-deploy.yml
+++ b/.github/workflows/cp-deploy.yml
@@ -54,7 +54,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #--v6.0.2
 
     - name: Obtain Octo STS Token
-      uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # v1.0.2
+      uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
       id: octo_sts
       with:
         scope: ministryofjustice/laa-generic-helm-chart

--- a/.github/workflows/cp-deploy.yml
+++ b/.github/workflows/cp-deploy.yml
@@ -53,10 +53,18 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #--v6.0.2
 
+    - name: Obtain Octo STS Token
+      uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # v1.0.2
+      id: octo_sts
+      with:
+        scope: ministryofjustice/laa-generic-helm-chart
+        identity: laa-reusable-actions-deploy
+
     - name: Clone Helm Chart
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #--v6.0.2
       with:
         repository: ministryofjustice/laa-generic-helm-chart
+        token: ${{ steps.octo_sts.outputs.token }}
         path: laa-generic-helm-chart
 
     - name: Kube Authentication


### PR DESCRIPTION
As ministryofjustice/laa-generic-helm-chart is not public we need a token to be able to clone the repo in this workflow. 

We could use PAT token but in order to avoid generating a PAT token, moj has octo-sts app enabled, which means we can use octo-sts/action to get required auth token to be able to clone the repo within the workflow