### PR TITLE
Chore: Update internal references

### DIFF
--- a/.github/actions/build_and_push_with_cache/action.yml
+++ b/.github/actions/build_and_push_with_cache/action.yml
@@ -14,7 +14,7 @@
 #       ${{ runner.os }}-buildx-
 #
 # - name: Build and push image with caching
-#   uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build_and_push_with_cache@main
+#   uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build_and_push_with_cache@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
 #   with:
 #     image_registry: ${{ secrets.ECR_REGISTRY_URL }}
 #     image_repo: ${{ vars.ECR_REPOSITORY }}

--- a/.github/actions/image-scan/README.md
+++ b/.github/actions/image-scan/README.md
@@ -10,7 +10,7 @@ Scans a container image for vulnerabilities using Snyk. Runs on every call, uplo
 ```yaml
 jobs:
   scan:
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/scan-image.yml@main
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/scan-image.yml@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
     with:
       image_uri: ${{ env.ECR_IMAGE }}
     secrets: inherit

--- a/.github/workflows/cp-build-push-deploy.yml
+++ b/.github/workflows/cp-build-push-deploy.yml
@@ -51,7 +51,7 @@ on:
 
 jobs:
   build_and_push:
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/cp-build-push.yml@main
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/cp-build-push.yml@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
     with:
       environment: ${{ inputs.environment }}
       dockerfile_path: ${{ inputs.dockerfile_path }}
@@ -62,7 +62,7 @@ jobs:
 
   helm_deploy:
     needs: build_and_push
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/cp-deploy.yml@main
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/cp-deploy.yml@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
     with:
       environment: ${{ inputs.environment }}
       image_repo: ${{ needs.build_and_push.outputs.image_repo }}

--- a/.github/workflows/cp-build-push.yml
+++ b/.github/workflows/cp-build-push.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: ECR Auth
       id: auth
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth/@main
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth/@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
       with:
         ecr_region: ${{ vars.ECR_REGION }}
         ecr_role: ${{ secrets.ECR_ROLE_TO_ASSUME }}
@@ -69,7 +69,7 @@ jobs:
 
     - name: Build and Push
       id: build
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@main
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
       with:
         dockerfile_path: ${{ inputs.dockerfile_path }}
         image_registry: ${{ steps.auth.outputs.image_registry }}
@@ -93,7 +93,7 @@ jobs:
 
   scan:
     needs: build_push
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/sast.yml@main
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/sast.yml@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
     with:
       image_uri: ${{ needs.build_push.outputs.image_uri }}
       dockerfile_path: ${{ inputs.dockerfile_path }}

--- a/.github/workflows/cp-deploy.yml
+++ b/.github/workflows/cp-deploy.yml
@@ -69,7 +69,7 @@ jobs:
 
     - name: Kube Authentication
       id: auth
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@main
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
       with:
         kube-cluster: ${{ secrets.KUBE_CLUSTER }}
         kube-namespace: ${{ secrets.KUBE_NAMESPACE }}
@@ -79,7 +79,7 @@ jobs:
 
     - name: Helm Deploy
       id: deploy
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/helm-deploy@main
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/helm-deploy@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
       with:
         k8s_namespace: ${{ secrets.KUBE_NAMESPACE }}
         helm_release_name: ${{ inputs.helm_release_name }}

--- a/.github/workflows/local-workflow.yml
+++ b/.github/workflows/local-workflow.yml
@@ -15,4 +15,4 @@ jobs:
           fetch-depth: 0
 
       - name: Secret Detection
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/secret-detection@main
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/secret-detection@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026

--- a/.github/workflows/mp-build-push.yml
+++ b/.github/workflows/mp-build-push.yml
@@ -58,7 +58,7 @@ jobs:
     #--Prereq steps https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/deploying-your-application.html#using-oidc-in-your-application-deployment-pipeline
     - name: ECR Auth
       id: auth
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth/@main
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth/@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
       with:
         ecr_region: ${{ vars.AWS_REGION }}
         ecr_role: arn:aws:iam::${{ secrets.DEPLOYMENT_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd
@@ -67,7 +67,7 @@ jobs:
 
     - name: Build and Push
       id: build
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@main
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
       with:
         dockerfile_path: ${{ inputs.dockerfile_path }}
         image_registry: ${{ steps.auth.outputs.image_registry }}
@@ -84,7 +84,7 @@ jobs:
 
     - name: Image Scan
       id: scan-post
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/image-scan@main
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/image-scan@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
       with:
         image_uri: ${{ steps.output.outputs.image_uri }}
         critical_high_exit_code: ${{ inputs.image_scan_critical_high_exit_code }}


### PR DESCRIPTION
These were created when `@main` was an allowable reference

This updates them to the current SHA for Main

The auto update job _should_ update them from there on out 🤞 