### PR TITLE
Chore: bump ecr-auth action dependencies

### DIFF
--- a/.github/actions/ecr-auth/action.yml
+++ b/.github/actions/ecr-auth/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
   - name: AWS Auth
     id: auth
-    uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+    uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
     with:
       role-to-assume: ${{ inputs.ecr_role }}
       aws-region: ${{ inputs.ecr_region }}
@@ -34,6 +34,6 @@ runs:
 
   - name: ECR Login
     id: login
-    uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
+    uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
     with:
       registries: ${{ inputs.account_ids }}

--- a/.github/workflows/cp-build-push.yml
+++ b/.github/workflows/cp-build-push.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: ECR Auth
       id: auth
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth/@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@0e69f22cd314ebc6a1bbb0dc16e515a90551e61f # SHA for branch
       with:
         ecr_region: ${{ vars.ECR_REGION }}
         ecr_role: ${{ secrets.ECR_ROLE_TO_ASSUME }}

--- a/.github/workflows/mp-build-push.yml
+++ b/.github/workflows/mp-build-push.yml
@@ -58,7 +58,7 @@ jobs:
     #--Prereq steps https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/deploying-your-application.html#using-oidc-in-your-application-deployment-pipeline
     - name: ECR Auth
       id: auth
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth/@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth/@0e69f22cd314ebc6a1bbb0dc16e515a90551e61f # SHA for branch
       with:
         ecr_region: ${{ vars.AWS_REGION }}
         ecr_role: arn:aws:iam::${{ secrets.DEPLOYMENT_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Configure AWS credentials for ECR access
         if: ${{ env.has_ecr_role == 'true' }}
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@e5500aa20b13a1406fe8a62b8788181a2ca18926
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@0e69f22cd314ebc6a1bbb0dc16e515a90551e61f # SHA for branch
         with:
           ecr_role: ${{ secrets.ECR_ROLE_TO_ASSUME }}
           ecr_region: "eu-west-2"


### PR DESCRIPTION
Bump ecr-auth action dependencies

> [!WARNING]
> Since the dependencies, aws-actions/amazon-ecr-login & actions/configure-aws-credentials, are actually sub-dependencies, of the ecr-auth action in this repo, we need to bump any internal references for that action. I am
using a sha from the commit which bumps the sub-dependencies, but after merge that ecr-auth reference could be bumped to anything from the merge commit onwards. I am not sure what the best way is to handle this. Perhaps a "release" PR afterward that updates the ecr-auth sha reference once merged?!

Bump from versions using node 20 to versions using node24. This
is to address node20s deprecation and vulnerabilities in node 20.

Fixes warning in GHA runner

```
run-sast-tooling / Scan IaC & Container with Snyk
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not
work as expected: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076, aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722.
Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if
updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable
on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For
more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```


### BEFORE
https://github.com/ministryofjustice/laa-apply-for-legal-aid/actions/runs/27347016934

<img width="2501" height="1094" alt="Screenshot 2026-06-11 at 17 23 59" src="https://github.com/user-attachments/assets/d896d501-2dad-49d5-94aa-32bded3adb61" />


### AFTER

https://github.com/ministryofjustice/laa-apply-for-legal-aid/actions/runs/27358836674

<img width="2546" height="765" alt="Screenshot 2026-06-11 at 17 23 24" src="https://github.com/user-attachments/assets/b3cf1bf4-767e-470e-8586-c9d69d6627dc" />
