### PR TITLE
Chore: Bump internal references to ecr-auth action

### DIFF
--- a/.github/workflows/cp-build-push.yml
+++ b/.github/workflows/cp-build-push.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: ECR Auth
       id: auth
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@0e69f22cd314ebc6a1bbb0dc16e515a90551e61f # SHA for branch
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@583a60502327d7b9b7701fdb11be9f7d096cf9f5 # SHA for main as of 12/06/2026
       with:
         ecr_region: ${{ vars.ECR_REGION }}
         ecr_role: ${{ secrets.ECR_ROLE_TO_ASSUME }}

--- a/.github/workflows/mp-build-push.yml
+++ b/.github/workflows/mp-build-push.yml
@@ -58,7 +58,7 @@ jobs:
     #--Prereq steps https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/deploying-your-application.html#using-oidc-in-your-application-deployment-pipeline
     - name: ECR Auth
       id: auth
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth/@0e69f22cd314ebc6a1bbb0dc16e515a90551e61f # SHA for branch
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@583a60502327d7b9b7701fdb11be9f7d096cf9f5 # SHA for main as of 12/06/2026
       with:
         ecr_region: ${{ vars.AWS_REGION }}
         ecr_role: arn:aws:iam::${{ secrets.DEPLOYMENT_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Configure AWS credentials for ECR access
         if: ${{ env.has_ecr_role == 'true' }}
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@0e69f22cd314ebc6a1bbb0dc16e515a90551e61f # SHA for branch
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@583a60502327d7b9b7701fdb11be9f7d096cf9f5 # SHA for main as of 12/06/2026
         with:
           ecr_role: ${{ secrets.ECR_ROLE_TO_ASSUME }}
           ecr_region: "eu-west-2"


### PR DESCRIPTION
Bump internal references to ecr-auth action

To use latest main branch SHA.

NOTE: this also corrects an error in the repo whereby the ecr-auth was being
referred to with a `/` in an inapprpriate place, meaning it should never have
worked anyway. This predates the branch that amended the sha too.
