### PR TITLE
make base image vulns optional

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: "high"
         type: string
+      exclude_base_image_vulns:
+        description: "Set true to pass --exclude-base-image-vulns to Snyk container scans"
+        required: false
+        default: false
+        type: boolean
       ecr_session_name:
         description: "The name of the session to use in ECR. Used for auditing purposes, set to what makes sense."
         required: false
@@ -104,12 +109,19 @@ jobs:
           MINIMUM_THRESHOLD: ${{ inputs.minimum_threshold }}
           INPUTS_IMAGE_URI: ${{ inputs.image_uri }}
           INPUTS_DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+          INPUTS_EXCLUDE_BASE_IMAGE_VULNS: ${{ inputs.exclude_base_image_vulns }}
         run: |
+          EXCLUDE_BASE_IMAGE_VULNS_FLAG=""
+          if [ "${INPUTS_EXCLUDE_BASE_IMAGE_VULNS}" = "true" ]; then
+            EXCLUDE_BASE_IMAGE_VULNS_FLAG="--exclude-base-image-vulns"
+          fi
+
           mkdir -p sarif
           snyk container test ${INPUTS_IMAGE_URI} \
             --severity-threshold=${MINIMUM_THRESHOLD} \
             --sarif-file-output=sarif/snyk.sarif \
-            --file=${INPUTS_DOCKERFILE_PATH}
+            --file=${INPUTS_DOCKERFILE_PATH} \
+            ${EXCLUDE_BASE_IMAGE_VULNS_FLAG}
 
       - name: Monitor current dependencies
         if: ${{ env.INPUTS_IMAGE_URI != '' }}

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -111,17 +111,27 @@ jobs:
           INPUTS_DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
           INPUTS_EXCLUDE_BASE_IMAGE_VULNS: ${{ inputs.exclude_base_image_vulns }}
         run: |
-          EXCLUDE_BASE_IMAGE_VULNS_FLAG=""
-          if [ "${INPUTS_EXCLUDE_BASE_IMAGE_VULNS}" = "true" ]; then
-            EXCLUDE_BASE_IMAGE_VULNS_FLAG="--exclude-base-image-vulns"
-          fi
+          case "${INPUTS_EXCLUDE_BASE_IMAGE_VULNS}" in
+            true|false) ;;
+            *)
+              echo "::error::exclude_base_image_vulns must be true or false"
+              exit 1
+              ;;
+          esac
 
           mkdir -p sarif
-          snyk container test ${INPUTS_IMAGE_URI} \
-            --severity-threshold=${MINIMUM_THRESHOLD} \
-            --sarif-file-output=sarif/snyk.sarif \
-            --file=${INPUTS_DOCKERFILE_PATH} \
-            ${EXCLUDE_BASE_IMAGE_VULNS_FLAG}
+          if [ "${INPUTS_EXCLUDE_BASE_IMAGE_VULNS}" = "true" ]; then
+            snyk container test "${INPUTS_IMAGE_URI}" \
+              --severity-threshold="${MINIMUM_THRESHOLD}" \
+              --sarif-file-output="sarif/snyk.sarif" \
+              --file="${INPUTS_DOCKERFILE_PATH}" \
+              --exclude-base-image-vulns
+          else
+            snyk container test "${INPUTS_IMAGE_URI}" \
+              --severity-threshold="${MINIMUM_THRESHOLD}" \
+              --sarif-file-output="sarif/snyk.sarif" \
+              --file="${INPUTS_DOCKERFILE_PATH}"
+          fi
 
       - name: Monitor current dependencies
         if: ${{ env.INPUTS_IMAGE_URI != '' }}

--- a/docs/README-sast.md
+++ b/docs/README-sast.md
@@ -51,6 +51,7 @@ change anything you don't need to.
 | `dockerfile_path` | No | `Dockerfile` | Path to the Dockerfile used by Snyk for context during container scanning. Relative to the top-level of the repository so unless you have a monorepo this is probably fine to leave |
 | `iac_path` | No | `""` | Path to Helm/IaC files. Leave unset to skip Infrastructure as Code scanning. |
 | `minimum_threshold` | No | `high` | Minimum severity level to report. One of: `low`, `medium`, `high`, `critical`. |
+| `exclude_base_image_vulns` | No | `false` | When `true`, appends `--exclude-base-image-vulns` to `snyk container test`. Useful when you want to focus on app-layer vulnerabilities and ignore base image findings. |
 | `ecr_session_name` | No | `laa-reusable-snyk` | Session name used when assuming the ECR role. Used for audit purposes. Unless you have a specific reason to override, you can leave this as default. |
 
 ## Secrets
@@ -187,6 +188,20 @@ jobs:
       image_uri: ${{ needs.build.outputs.image_uri }}
       iac_path: helm/deployment
       minimum_threshold: medium
+    secrets:
+      SNYK_CLIENT_ID: ${{ secrets.SNYK_CLIENT_ID }}
+      SNYK_CLIENT_SECRET: ${{ secrets.SNYK_CLIENT_SECRET }}
+      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+```
+
+### Exclude base image vulnerabilities from container scan results
+
+```yaml
+  sast:
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/sast.yml@<insert latest sha here>
+    with:
+      image_uri: ${{ needs.build.outputs.image_uri }}
+      exclude_base_image_vulns: true
     secrets:
       SNYK_CLIENT_ID: ${{ secrets.SNYK_CLIENT_ID }}
       SNYK_CLIENT_SECRET: ${{ secrets.SNYK_CLIENT_SECRET }}


### PR DESCRIPTION
Added a boolean flag to apply the sast job to apply `--exclude-base-image-vulns`
defaults to false so it will not break current uses of the action