### PR TITLE
Cm 346 update snyk

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -67,12 +67,16 @@ jobs:
           echo "has_oauth=${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}" >> $GITHUB_ENV
           echo "has_ecr_role=${{ secrets.ECR_ROLE_TO_ASSUME != '' }}" >> $GITHUB_ENV
 
+          has_token="${{ secrets.SNYK_TOKEN != '' }}"
+          has_oauth="${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}"
+          has_ecr_role="${{ secrets.ECR_ROLE_TO_ASSUME != '' }}"
+
           if [[ "$has_token" == 'false' && "$has_oauth" == 'false' ]]; then
             echo "::error::Either SNYK_TOKEN or both SNYK_CLIENT_ID and SNYK_CLIENT_SECRET must be set"
             exit 1
           fi
 
-          if [[ "${{ inputs.image_uri }}" != '' && "$HAS_ECR_ROLE" == 'false' ]]; then
+          if [[ "${{ inputs.image_uri }}" != '' && "$has_ecr_role" == 'false' ]]; then
             echo "::error::image_uri was provided but no ECR role is configured. Set the ECR_ROLE_TO_ASSUME secret or pass the ecr_role input."
             exit 1
           fi
@@ -107,7 +111,7 @@ jobs:
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04
 
       - name: Scan dependencies using container runtime
-        if: ${{ env.INPUTS_IMAGE_URI != '' }}
+        if: ${{ inputs.image_uri != '' }}
         env:
           SNYK_OAUTH_TOKEN: ${{ steps.auth.outputs.token }}
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: "laa-reusable-snyk"
         type: string
+      ecr_role:
+        description: "IAM Role ARN for ECR access. Use this when your repo's ECR role secret is not named ECR_ROLE_TO_ASSUME (e.g. due to a github_actions_prefix in the Cloud Platform ECR module)."
+        required: false
+        default: ""
+        type: string
     # These secrets MUST be set to authenticate
     # You can alternatively also pass a static token in to authenticate
     secrets:
@@ -65,7 +70,7 @@ jobs:
         run: |
           echo "has_token=${{ secrets.SNYK_TOKEN != '' }}" >> $GITHUB_ENV
           echo "has_oauth=${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}" >> $GITHUB_ENV
-          echo "has_ecr_role=${{ secrets.ECR_ROLE_TO_ASSUME != '' }}" >> $GITHUB_ENV
+          echo "has_ecr_role=${{ inputs.ecr_role != '' || secrets.ECR_ROLE_TO_ASSUME != '' }}" >> $GITHUB_ENV
 
           if [[ "$has_token" == 'false' && "$has_oauth" == 'false' ]]; then
             echo "::error::Either SNYK_TOKEN or both SNYK_CLIENT_ID and SNYK_CLIENT_SECRET must be set"
@@ -86,7 +91,7 @@ jobs:
         if: ${{ env.has_ecr_role == 'true' }}
         uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@583a60502327d7b9b7701fdb11be9f7d096cf9f5 # SHA for main as of 12/06/2026
         with:
-          ecr_role: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          ecr_role: ${{ inputs.ecr_role != '' && inputs.ecr_role || secrets.ECR_ROLE_TO_ASSUME }}
           ecr_region: "eu-west-2"
           role-session-name: ${{ inputs.ecr_session_name }}
 

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -186,7 +186,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: "sarif"
-
-#      - name: Fail if container scan found issues
-#        if: ${{ always() && steps.container_scan.outcome == 'failure' }}
-#        run: exit 1

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -65,28 +65,25 @@ jobs:
         env:
           INPUTS_IMAGE_URI: ${{ inputs.image_uri }}
         run: |
-          echo "has_token=${{ secrets.SNYK_TOKEN != '' }}" >> $GITHUB_ENV
-          echo "has_oauth=${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}" >> $GITHUB_ENV
+          echo "has_token=false" >> $GITHUB_ENV
+          echo "has_oauth=false" >> $GITHUB_ENV
           echo "has_ecr_role=${{ secrets.ECR_ROLE_TO_ASSUME != '' }}" >> $GITHUB_ENV
 
           # Demo output: values written to GITHUB_ENV are not available in this same shell step.
           echo "demo: has_token before assignment='${has_token-<unset>}'"
           echo "demo: expression has_token='${{ secrets.SNYK_TOKEN != '' }}'"
 
-          has_token="${{ secrets.SNYK_TOKEN != '' }}"
-          has_oauth="${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}"
-          has_ecr_role="${{ secrets.ECR_ROLE_TO_ASSUME != '' }}"
-
-          echo "demo: has_token after assignment='${has_token}'"
 
           if [[ "$has_token" == 'false' && "$has_oauth" == 'false' ]]; then
             echo "::error::Either SNYK_TOKEN or both SNYK_CLIENT_ID and SNYK_CLIENT_SECRET must be set"
             exit 1
+          else
+            echo "demo: guard bypassed in same step because has_token/has_oauth are unset (GITHUB_ENV not yet applied)"
           fi
 
-          if [[ "${INPUTS_IMAGE_URI}" != '' && "$has_ecr_role" == 'false' ]]; then
+          if [[ "${INPUTS_IMAGE_URI}" != ''&& "$has_ecr_role" == 'false' ]]; then
             echo "::error::image_uri was provided but no ECR role is configured. Set the ECR_ROLE_TO_ASSUME secret or pass the ecr_role input."
-            exit 1
+            exit 1 
           fi
 
       # Early exit if there's no container setup to scan

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -65,25 +65,28 @@ jobs:
         env:
           INPUTS_IMAGE_URI: ${{ inputs.image_uri }}
         run: |
-          echo "has_token=false" >> $GITHUB_ENV
-          echo "has_oauth=false" >> $GITHUB_ENV
+          echo "has_token=${{ secrets.SNYK_TOKEN != '' }}" >> $GITHUB_ENV
+          echo "has_oauth=${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}" >> $GITHUB_ENV
           echo "has_ecr_role=${{ secrets.ECR_ROLE_TO_ASSUME != '' }}" >> $GITHUB_ENV
 
           # Demo output: values written to GITHUB_ENV are not available in this same shell step.
           echo "demo: has_token before assignment='${has_token-<unset>}'"
           echo "demo: expression has_token='${{ secrets.SNYK_TOKEN != '' }}'"
 
+          has_token="${{ secrets.SNYK_TOKEN != '' }}"
+          has_oauth="${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}"
+          has_ecr_role="${{ secrets.ECR_ROLE_TO_ASSUME != '' }}"
+
+          echo "demo: has_token after assignment='${has_token}'"
 
           if [[ "$has_token" == 'false' && "$has_oauth" == 'false' ]]; then
             echo "::error::Either SNYK_TOKEN or both SNYK_CLIENT_ID and SNYK_CLIENT_SECRET must be set"
             exit 1
-          else
-            echo "demo: guard bypassed in same step because has_token/has_oauth are unset (GITHUB_ENV not yet applied)"
           fi
 
-          if [[ "${INPUTS_IMAGE_URI}" != ''&& "$has_ecr_role" == 'false' ]]; then
+          if [[ "${INPUTS_IMAGE_URI}" != '' && "$has_ecr_role" == 'false' ]]; then
             echo "::error::image_uri was provided but no ECR role is configured. Set the ECR_ROLE_TO_ASSUME secret or pass the ecr_role input."
-            exit 1 
+            exit 1
           fi
 
       # Early exit if there's no container setup to scan

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -69,15 +69,9 @@ jobs:
           echo "has_oauth=${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}" >> $GITHUB_ENV
           echo "has_ecr_role=${{ secrets.ECR_ROLE_TO_ASSUME != '' }}" >> $GITHUB_ENV
 
-          # Demo output: values written to GITHUB_ENV are not available in this same shell step.
-          echo "demo: has_token before assignment='${has_token-<unset>}'"
-          echo "demo: expression has_token='${{ secrets.SNYK_TOKEN != '' }}'"
-
           has_token="${{ secrets.SNYK_TOKEN != '' }}"
           has_oauth="${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}"
           has_ecr_role="${{ secrets.ECR_ROLE_TO_ASSUME != '' }}"
-
-          echo "demo: has_token after assignment='${has_token}'"
 
           if [[ "$has_token" == 'false' && "$has_oauth" == 'false' ]]; then
             echo "::error::Either SNYK_TOKEN or both SNYK_CLIENT_ID and SNYK_CLIENT_SECRET must be set"

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -62,21 +62,29 @@ jobs:
 
       # Secrets can't be used in if-checks so we have to define a global flag to verify
       - name: Check if we have tokens defined
+        env:
+          INPUTS_IMAGE_URI: ${{ inputs.image_uri }}
         run: |
           echo "has_token=${{ secrets.SNYK_TOKEN != '' }}" >> $GITHUB_ENV
           echo "has_oauth=${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}" >> $GITHUB_ENV
           echo "has_ecr_role=${{ secrets.ECR_ROLE_TO_ASSUME != '' }}" >> $GITHUB_ENV
 
+          # Demo output: values written to GITHUB_ENV are not available in this same shell step.
+          echo "demo: has_token before assignment='${has_token-<unset>}'"
+          echo "demo: expression has_token='${{ secrets.SNYK_TOKEN != '' }}'"
+
           has_token="${{ secrets.SNYK_TOKEN != '' }}"
           has_oauth="${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}"
           has_ecr_role="${{ secrets.ECR_ROLE_TO_ASSUME != '' }}"
+
+          echo "demo: has_token after assignment='${has_token}'"
 
           if [[ "$has_token" == 'false' && "$has_oauth" == 'false' ]]; then
             echo "::error::Either SNYK_TOKEN or both SNYK_CLIENT_ID and SNYK_CLIENT_SECRET must be set"
             exit 1
           fi
 
-          if [[ "${{ inputs.image_uri }}" != '' && "$has_ecr_role" == 'false' ]]; then
+          if [[ "${INPUTS_IMAGE_URI}" != '' && "$has_ecr_role" == 'false' ]]; then
             echo "::error::image_uri was provided but no ECR role is configured. Set the ECR_ROLE_TO_ASSUME secret or pass the ecr_role input."
             exit 1
           fi

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -68,12 +68,21 @@ jobs:
       # Secrets can't be used in if-checks so we have to define a global flag to verify
       - name: Check if we have tokens defined
         run: |
-          echo "has_token=${{ secrets.SNYK_TOKEN != '' }}" >> $GITHUB_ENV
-          echo "has_oauth=${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}" >> $GITHUB_ENV
-          echo "has_ecr_role=${{ inputs.ecr_role != '' || secrets.ECR_ROLE_TO_ASSUME != '' }}" >> $GITHUB_ENV
+          HAS_TOKEN="${{ secrets.SNYK_TOKEN != '' }}"
+          HAS_OAUTH="${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != '' }}"
+          HAS_ECR_ROLE="${{ inputs.ecr_role != '' || secrets.ECR_ROLE_TO_ASSUME != '' }}"
 
-          if [[ "$has_token" == 'false' && "$has_oauth" == 'false' ]]; then
+          echo "has_token=$HAS_TOKEN" >> $GITHUB_ENV
+          echo "has_oauth=$HAS_OAUTH" >> $GITHUB_ENV
+          echo "has_ecr_role=$HAS_ECR_ROLE" >> $GITHUB_ENV
+
+          if [[ "$HAS_TOKEN" == 'false' && "$HAS_OAUTH" == 'false' ]]; then
             echo "::error::Either SNYK_TOKEN or both SNYK_CLIENT_ID and SNYK_CLIENT_SECRET must be set"
+            exit 1
+          fi
+
+          if [[ "${{ inputs.image_uri }}" != '' && "$HAS_ECR_ROLE" == 'false' ]]; then
+            echo "::error::image_uri was provided but no ECR role is configured. Set the ECR_ROLE_TO_ASSUME secret or pass the ecr_role input."
             exit 1
           fi
 

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -113,7 +113,7 @@ jobs:
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04
 
       - name: Scan dependencies using container runtime
-        if: ${{ inputs.image_uri != '' }}
+        if: ${{ env.INPUTS_IMAGE_URI != '' }}
         env:
           SNYK_OAUTH_TOKEN: ${{ steps.auth.outputs.token }}
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -145,7 +145,7 @@ jobs:
           fi
 
       - name: Monitor current dependencies
-        if: ${{ inputs.image_uri != '' }}
+        if: ${{ env.INPUTS_IMAGE_URI != '' }}
         env:
           SNYK_OAUTH_TOKEN: ${{ steps.auth.outputs.token }}
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -33,11 +33,6 @@ on:
         required: false
         default: "laa-reusable-snyk"
         type: string
-      ecr_role:
-        description: "IAM Role ARN for ECR access. Use this when your repo's ECR role secret is not named ECR_ROLE_TO_ASSUME (e.g. due to a github_actions_prefix in the Cloud Platform ECR module)."
-        required: false
-        default: ""
-        type: string
     # These secrets MUST be set to authenticate
     # You can alternatively also pass a static token in to authenticate
     secrets:
@@ -68,15 +63,11 @@ jobs:
       # Secrets can't be used in if-checks so we have to define a global flag to verify
       - name: Check if we have tokens defined
         run: |
-          HAS_TOKEN="${{ secrets.SNYK_TOKEN != '' }}"
-          HAS_OAUTH="${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != '' }}"
-          HAS_ECR_ROLE="${{ inputs.ecr_role != '' || secrets.ECR_ROLE_TO_ASSUME != '' }}"
+          echo "has_token=${{ secrets.SNYK_TOKEN != '' }}" >> $GITHUB_ENV
+          echo "has_oauth=${{ secrets.SNYK_CLIENT_ID != '' && secrets.SNYK_CLIENT_SECRET != ''}}" >> $GITHUB_ENV
+          echo "has_ecr_role=${{ secrets.ECR_ROLE_TO_ASSUME != '' }}" >> $GITHUB_ENV
 
-          echo "has_token=$HAS_TOKEN" >> $GITHUB_ENV
-          echo "has_oauth=$HAS_OAUTH" >> $GITHUB_ENV
-          echo "has_ecr_role=$HAS_ECR_ROLE" >> $GITHUB_ENV
-
-          if [[ "$HAS_TOKEN" == 'false' && "$HAS_OAUTH" == 'false' ]]; then
+          if [[ "$has_token" == 'false' && "$has_oauth" == 'false' ]]; then
             echo "::error::Either SNYK_TOKEN or both SNYK_CLIENT_ID and SNYK_CLIENT_SECRET must be set"
             exit 1
           fi
@@ -100,7 +91,7 @@ jobs:
         if: ${{ env.has_ecr_role == 'true' }}
         uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@583a60502327d7b9b7701fdb11be9f7d096cf9f5 # SHA for main as of 12/06/2026
         with:
-          ecr_role: ${{ inputs.ecr_role != '' && inputs.ecr_role || secrets.ECR_ROLE_TO_ASSUME }}
+          ecr_role: ${{ secrets.ECR_ROLE_TO_ASSUME }}
           ecr_region: "eu-west-2"
           role-session-name: ${{ inputs.ecr_session_name }}
 
@@ -148,7 +139,7 @@ jobs:
           fi
 
       - name: Monitor current dependencies
-        if: ${{ env.INPUTS_IMAGE_URI != '' }}
+        if: ${{ inputs.image_uri != '' }}
         env:
           SNYK_OAUTH_TOKEN: ${{ steps.auth.outputs.token }}
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -195,3 +186,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: "sarif"
+
+#      - name: Fail if container scan found issues
+#        if: ${{ always() && steps.container_scan.outcome == 'failure' }}
+#        run: exit 1


### PR DESCRIPTION
CM-346

- updated gate on inputs.image_uri (instead of step-local env.INPUTS_IMAGE_URI), so that if an image URI is provided but an ECR role is not then the workflow fails
- fix guard evaluation in Check if we have tokens defined by using local shell variables for same-step checks
- corrected the ECR role variable reference from HAS_ECR_ROLE to has_ecr_role.
