### PR TITLE
Feat/java pipeline refactor

### DIFF
--- a/.github/actions/build-and-push/README.md
+++ b/.github/actions/build-and-push/README.md
@@ -1,0 +1,22 @@
+# Build and push image
+
+Composite action for building, tagging and optionally publishing an image. Dockerfile mode is the
+default; `gradle-buildpacks` runs `./gradlew bootBuildImage`.
+
+```yaml
+- id: image
+  uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@<immutable-sha>
+  with:
+    image_registry: ${{ steps.ecr.outputs.image_registry }}
+    image_repo: ${{ vars.ECR_REPOSITORY }}
+    image_tag: ${{ github.sha }}
+    build_mode: gradle-buildpacks
+    jar_subproject: service
+    additional_image_tags: '["latest"]'
+```
+
+Inputs are `image_registry`, `image_repo`, `image_tag`, `dockerfile_path`, `build_mode`,
+`docker_build_args`, `jar_subproject`, `dockerfile_requires_git`, `additional_image_tags`, `build`
+and `push`. `build` and `push` default to `true`; additional tags must be a JSON array.
+
+Outputs are `image_registry`, `image_repo`, `image_tag` and the complete `image_uri`.

--- a/.github/actions/build-and-push/action.yml
+++ b/.github/actions/build-and-push/action.yml
@@ -12,6 +12,18 @@ inputs:
     required: true
     description: "Dockerfile Path"
     default: "Dockerfile" #--Dockerfile in current working directory
+  build_mode:
+    required: false
+    description: "Image build mode: 'dockerfile' or 'gradle-buildpacks'"
+    default: "dockerfile"
+  docker_build_args:
+    required: false
+    description: "Additional arguments passed to docker build in dockerfile mode"
+    default: ""
+  jar_subproject:
+    required: false
+    description: "Gradle subproject containing the bootBuildImage task"
+    default: ""
   image_tag:
     required: true
     description: "Image Tag"
@@ -24,6 +36,14 @@ inputs:
     required: false
     description: "JSON array of additional tags to apply to the image, e.g. '[\"latest\",\"stable\"]'"
     default: "[]"
+  push:
+    required: false
+    description: "Push the image and any additional tags to the registry"
+    default: "true"
+  build:
+    required: false
+    description: "Build the image before applying tags and optionally pushing it"
+    default: "true"
 
 outputs:
   image_registry:
@@ -43,34 +63,81 @@ runs:
   using: "composite"
 
   steps:
-  - name: Docker Build
+  - name: Build and Push
     id: build_and_push
     run: |
-      docker build . \
-        -t "${{ inputs.image_registry }}/${{ inputs.image_repo }}:${{ inputs.image_tag }}" \
-        -f "${{ inputs.dockerfile_path }}" \
-        ${{ inputs.dockerfile_requires_git == 'true' && '--secret id=git_token,env=GIT_TOKEN' || '' }}
+      set -euo pipefail
+      image_name="${IMAGE_REGISTRY}/${IMAGE_REPO}:${IMAGE_TAG}"
 
-      docker push "${{ inputs.image_registry }}/${{ inputs.image_repo }}:${{ inputs.image_tag }}"
-
-      ADDITIONAL_TAGS='${{ inputs.additional_image_tags }}'
-      if [ -n "$ADDITIONAL_TAGS" ] && [ "$ADDITIONAL_TAGS" != "[]" ]; then
-        echo "$ADDITIONAL_TAGS" | jq -r '.[]' | while read -r tag; do
-          docker tag \
-            "${{ inputs.image_registry }}/${{ inputs.image_repo }}:${{ inputs.image_tag }}" \
-            "${{ inputs.image_registry }}/${{ inputs.image_repo }}:${tag}"
-          docker push "${{ inputs.image_registry }}/${{ inputs.image_repo }}:${tag}"
-        done
+      if [[ "$BUILD" == "true" ]]; then
+        case "$BUILD_MODE" in
+          dockerfile)
+            docker_args=()
+            if [[ -n "$DOCKER_BUILD_ARGS" ]]; then
+              read -r -a docker_args <<< "$DOCKER_BUILD_ARGS"
+            fi
+            if [[ "$DOCKERFILE_REQUIRES_GIT" == "true" ]]; then
+              docker_args+=(--secret id=git_token,env=GIT_TOKEN)
+            fi
+            docker build . -t "$image_name" -f "$DOCKERFILE_PATH" "${docker_args[@]}"
+            ;;
+          gradle-buildpacks)
+            gradle_subproject=""
+            if [[ -n "$JAR_SUBPROJECT" ]]; then
+              gradle_subproject=":${JAR_SUBPROJECT}:"
+            fi
+            ./gradlew "${gradle_subproject}bootBuildImage" --imageName "$image_name"
+            ;;
+          *)
+            echo "::error::Unsupported build_mode '${BUILD_MODE}'. Expected 'dockerfile' or 'gradle-buildpacks'."
+            exit 1
+            ;;
+        esac
       fi
+
+      additional_tags=()
+      if [ -n "$ADDITIONAL_TAGS" ] && [ "$ADDITIONAL_TAGS" != "[]" ]; then
+        mapfile -t additional_tags < <(jq -r '.[]' <<< "$ADDITIONAL_TAGS")
+      fi
+
+      for tag in "${additional_tags[@]}"; do
+        docker tag \
+          "$image_name" \
+          "${IMAGE_REGISTRY}/${IMAGE_REPO}:${tag}"
+      done
+
+      if [[ "$PUSH" != "true" ]]; then
+        exit 0
+      fi
+
+      docker push "$image_name"
+      for tag in "${additional_tags[@]}"; do
+        docker push "${IMAGE_REGISTRY}/${IMAGE_REPO}:${tag}"
+      done
     shell: bash
     env:
+      ADDITIONAL_TAGS: ${{ inputs.additional_image_tags }}
+      BUILD: ${{ inputs.build }}
+      BUILD_MODE: ${{ inputs.build_mode }}
+      DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+      DOCKERFILE_REQUIRES_GIT: ${{ inputs.dockerfile_requires_git }}
+      DOCKER_BUILD_ARGS: ${{ inputs.docker_build_args }}
       GIT_TOKEN: ${{ github.token }}
+      IMAGE_REGISTRY: ${{ inputs.image_registry }}
+      IMAGE_REPO: ${{ inputs.image_repo }}
+      IMAGE_TAG: ${{ inputs.image_tag }}
+      JAR_SUBPROJECT: ${{ inputs.jar_subproject }}
+      PUSH: ${{ inputs.push }}
 
   - name: Output
     id: output
     run: |
-      echo image_registry=${{ inputs.image_registry }} >> "$GITHUB_OUTPUT"
-      echo image_repo=${{ inputs.image_repo }} >> "$GITHUB_OUTPUT"
-      echo image_tag=${{ inputs.image_tag }} >> "$GITHUB_OUTPUT"
-      echo image_uri="${{ inputs.image_registry }}/${{ inputs.image_repo }}:${{ inputs.image_tag }}"
+      echo "image_registry=${IMAGE_REGISTRY}" >> "$GITHUB_OUTPUT"
+      echo "image_repo=${IMAGE_REPO}" >> "$GITHUB_OUTPUT"
+      echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+      echo "image_uri=${IMAGE_REGISTRY}/${IMAGE_REPO}:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
     shell: bash
+    env:
+      IMAGE_REGISTRY: ${{ inputs.image_registry }}
+      IMAGE_REPO: ${{ inputs.image_repo }}
+      IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/actions/compute-version/README.md
+++ b/.github/actions/compute-version/README.md
@@ -1,0 +1,19 @@
+# Compute version
+
+Computes a semantic version from Git tags and Conventional Commits. Checkout full history first.
+
+```yaml
+- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+  with:
+    fetch-depth: 0
+    fetch-tags: true
+- id: version
+  uses: ministryofjustice/laa-reusable-github-actions/.github/actions/compute-version@<immutable-sha>
+  with:
+    bump: ${{ inputs.release_type || '' }}
+```
+
+`bump` accepts `major`, `minor`, `patch`, `none`, or empty auto-detection. The action understands
+`v1.2.3`, legacy `repository-1.2.3`, and bare `1.2.3` tags.
+
+Outputs: `prev_tag`, `bump_type`, `major`, `minor`, `patch`, and `next_version`.

--- a/.github/actions/compute-version/action.yml
+++ b/.github/actions/compute-version/action.yml
@@ -1,0 +1,128 @@
+name: "Compute version"
+description: >
+  Resolves the previous Release Tag, detects the Bump Type from Conventional Commits,
+  and computes the next semver version. Used by release pipelines to drive a
+  git-tag-based release process.
+
+  Tag resolution: prefers v{semver} tags (new scheme); falls back to {repo-name}-{semver}
+  tags (old Gradle Release Plugin scheme). The fallback can be removed once all
+  repositories have at least one v-prefix Release Tag.
+
+inputs:
+  bump:
+    description: >
+      Override the detected bump type. One of: major | minor | patch | none.
+      When empty (default), bump type is auto-detected from Conventional Commits.
+    required: false
+    default: ''
+
+outputs:
+  prev_tag:
+    description: "Last Release Tag found (e.g. v1.2.3), or v0.0.0 if none."
+    value: ${{ steps.compute.outputs.prev_tag }}
+  bump_type:
+    description: "Detected bump type: major | minor | patch | none."
+    value: ${{ steps.compute.outputs.bump_type }}
+  major:
+    description: "Major component of the next version (or current if bump_type=none)."
+    value: ${{ steps.compute.outputs.major }}
+  minor:
+    description: "Minor component of the next version (or current if bump_type=none)."
+    value: ${{ steps.compute.outputs.minor }}
+  patch:
+    description: "Patch component of the next version (or current if bump_type=none)."
+    value: ${{ steps.compute.outputs.patch }}
+  next_version:
+    description: "Next Release Tag (e.g. v1.3.0), or empty string when bump_type=none."
+    value: ${{ steps.compute.outputs.next_version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Compute version
+      id: compute
+      shell: bash
+      env:
+        BUMP_OVERRIDE: ${{ inputs.bump }}
+      run: |
+        set -euo pipefail
+
+        REPO_NAME="$(basename "$(git rev-parse --show-toplevel)")"
+
+        # Tag resolution: prefer v-prefix tags (new scheme); fall back to {repo-name}-{version}
+        # or bare semver tags (old Gradle Release Plugin schemes). Fallbacks can be removed once
+        # all repositories have at least one v-prefix Release Tag.
+        PREV_TAG_REF="$(git describe --tags --abbrev=0 --match "v[0-9]*" 2>/dev/null || true)"
+        PREV_TAG="$PREV_TAG_REF"
+        if [ -z "$PREV_TAG_REF" ]; then
+          OLD_TAG="$(git describe --tags --abbrev=0 --match "${REPO_NAME}-[0-9]*" 2>/dev/null || true)"
+          if [ -n "$OLD_TAG" ]; then
+            PREV_TAG_REF="$OLD_TAG"
+            PREV_TAG="v${OLD_TAG#${REPO_NAME}-}"
+          fi
+        fi
+        if [ -z "$PREV_TAG_REF" ]; then
+          BARE_TAG="$(git describe --tags --abbrev=0 --match "[0-9]*" 2>/dev/null || true)"
+          if [ -n "$BARE_TAG" ]; then
+            PREV_TAG_REF="$BARE_TAG"
+            PREV_TAG="v${BARE_TAG}"
+          fi
+        fi
+        PREV_TAG="${PREV_TAG:-v0.0.0}"
+
+        if [[ -n "$PREV_TAG_REF" ]] && git merge-base --is-ancestor "$PREV_TAG_REF" HEAD 2>/dev/null; then
+          COMMITS="${PREV_TAG_REF}..HEAD"
+        else
+          COMMITS="HEAD"
+        fi
+
+        # Bump-type detection: use BUMP_OVERRIDE if set, otherwise detect from Conventional Commits.
+        # Defaults to 'patch' if no pattern matches, ensuring every push to main produces a release.
+        # Use release_type=none to explicitly skip releasing.
+        # Note: grep without -m1 avoids SIGPIPE/pipefail false-negatives on large repos.
+        BUMP="patch"
+        if [[ -n "${BUMP_OVERRIDE:-}" ]]; then
+          BUMP="$BUMP_OVERRIDE"
+        elif (git log --no-merges --format=%s "$COMMITS" | grep -Eq '^[a-z]+(\([^)]+\))?!: '); then
+          BUMP="major"
+        elif (git log --no-merges --format=%B "$COMMITS" | grep -Eq 'BREAKING[ -]CHANGE:'); then
+          BUMP="major"
+        elif (git log --no-merges --format=%s "$COMMITS" | grep -Eq '^feat(\([^)]+\))?: '); then
+          BUMP="minor"
+        fi
+
+        case "$BUMP" in
+          major|minor|patch|none) ;;
+          *)
+            echo "::error::Unsupported bump '${BUMP}'. Expected major, minor, patch, or none."
+            exit 1
+            ;;
+        esac
+
+        # Semver arithmetic
+        if [[ "$PREV_TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+          MAJOR=${BASH_REMATCH[1]}; MINOR=${BASH_REMATCH[2]}; PATCH=${BASH_REMATCH[3]}
+        else
+          MAJOR=0; MINOR=0; PATCH=0
+        fi
+        case "$BUMP" in
+          major) MAJOR=$((MAJOR+1)); MINOR=0; PATCH=0 ;;
+          minor) MINOR=$((MINOR+1)); PATCH=0 ;;
+          patch) PATCH=$((PATCH+1)) ;;
+          none)  ;;
+        esac
+
+        NEXT_VERSION=""
+        if [[ "$BUMP" != "none" ]]; then NEXT_VERSION="v${MAJOR}.${MINOR}.${PATCH}"; fi
+
+        emit() {
+          echo "$1"
+          if [[ -n "${GITHUB_OUTPUT:-}" ]]; then echo "$1" >> "$GITHUB_OUTPUT"; fi
+        }
+
+        emit "prev_tag=${PREV_TAG}"
+        emit "bump_type=${BUMP}"
+        emit "major=${MAJOR}"
+        emit "minor=${MINOR}"
+        emit "patch=${PATCH}"
+        emit "next_version=${NEXT_VERSION}"

--- a/.github/actions/git-release/README.md
+++ b/.github/actions/git-release/README.md
@@ -1,0 +1,18 @@
+# Git release
+
+Idempotently creates an annotated Git tag and, by default, a GitHub Release.
+
+```yaml
+- id: release
+  uses: ministryofjustice/laa-reusable-github-actions/.github/actions/git-release@<immutable-sha>
+  with:
+    tag: ${{ steps.version.outputs.next_version }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The caller needs `contents: write`; checkout must retain credentials capable of pushing the tag.
+Inputs are `tag` (required), `github_bot_username`, `github_token`, and
+`create_github_release` (default `true`). The `gtag` output contains the existing or created tag.
+
+To publish an artifact between tagging and creating the GitHub Release, call once with
+`create_github_release: 'false'`, publish using `gtag`, then call again with the same tag.

--- a/.github/actions/git-release/action.yml
+++ b/.github/actions/git-release/action.yml
@@ -1,0 +1,73 @@
+name: "Create Git release"
+description: >
+  Creates an annotated Git tag and a GitHub Release for a computed version.
+  Existing remote tags and GitHub Releases are left unchanged.
+
+inputs:
+  tag:
+    required: true
+    description: "Computed release tag to create (for example, v1.2.3)."
+  github_bot_username:
+    required: false
+    description: "GitHub bot username used to create the annotated tag."
+    default: "github-actions-bot"
+  github_token:
+    required: false
+    description: "GitHub token used to create the release. Defaults to the workflow token."
+    default: ''
+  create_github_release:
+    required: false
+    description: "Create the GitHub Release after ensuring the tag exists."
+    default: 'true'
+
+outputs:
+  gtag:
+    description: "The existing or newly-created Git release tag."
+    value: ${{ steps.create-tag.outputs.gtag }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create Git tag
+      id: create-tag
+      shell: bash
+      env:
+        GTAG: ${{ inputs.tag }}
+        BOT_USERNAME: ${{ inputs.github_bot_username }}
+      run: |
+        set -eu
+        test -n "$GTAG"
+        git config user.name "${BOT_USERNAME}[bot]"
+        git config user.email "${BOT_USERNAME}[bot]@users.noreply.github.com"
+        if git ls-remote --tags origin | grep -q "refs/tags/${GTAG}$"; then
+          echo "Tag ${GTAG} already exists on remote. Skipping."
+          echo "gtag=${GTAG}" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "Creating Git tag [${GTAG}]"
+        git tag -a "$GTAG" -m "Release ${GTAG}"
+        git push origin "$GTAG" || {
+          EXIT=$?
+          if git ls-remote --tags origin | grep -q "refs/tags/${GTAG}$"; then
+            echo "Tag ${GTAG} was already pushed (race condition). Skipping."
+          else
+            echo "::error::Failed to push tag ${GTAG} (exit ${EXIT})"
+            exit $EXIT
+          fi
+        }
+        echo "gtag=${GTAG}" >> "$GITHUB_OUTPUT"
+
+    - name: Create GitHub Release
+      if: ${{ inputs.create_github_release == 'true' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token || github.token }}
+        GTAG: ${{ steps.create-tag.outputs.gtag }}
+      run: |
+        test -n "$GTAG"
+        if gh release view "$GTAG" >/dev/null 2>&1; then
+          echo "Release ${GTAG} already exists. Skipping."
+          exit 0
+        fi
+        echo "Creating GitHub Release [${GTAG}]"
+        gh release create "$GTAG" --verify-tag --title "$GTAG" --generate-notes

--- a/.github/actions/image-scan/README.md
+++ b/.github/actions/image-scan/README.md
@@ -1,30 +1,32 @@
-# scan-image
+# Snyk image scan
 
-Scans a container image for vulnerabilities using Snyk. Runs on every call, uploads results to GitHub Code Scanning, and tracks the image in the Snyk dashboard.
-
-> [!NOTE]
-> This workflow should be considered deprecated and instead use [sast.yml](../../workflows/sast.yml)
-
-## Usage
+Composite action that scans an existing local or registry image with Snyk, cleanses the SARIF
+report, optionally uploads it to GitHub code scanning, and fails after reporting vulnerabilities.
 
 ```yaml
-jobs:
-  scan:
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/scan-image.yml@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
-    with:
-      image_uri: ${{ env.ECR_IMAGE }}
-    secrets: inherit
+- name: Scan image
+  uses: ministryofjustice/laa-reusable-github-actions/.github/actions/image-scan@<immutable-sha>
+  with:
+    image_uri: ${{ steps.build.outputs.image_uri }}
+    dockerfile_path: Dockerfile
+    snyk_client_id: ${{ secrets.SNYK_CLIENT_ID }}
+    snyk_client_secret: ${{ secrets.SNYK_CLIENT_SECRET }}
+    severity: high
+    fail_on: upgradable
 ```
 
-## Inputs
+OAuth credentials are preferred. `snyk_token` is retained as a deprecated fallback and produces a
+migration warning. Set `dockerfile_path: ''` for buildpacks images without a Dockerfile.
 
-| Name | Required | Default | Description |
-|------|----------|---------|-------------|
-| `image_uri` | yes | | Full URI of the image to scan |
-| `dockerfile_path` | no | `Dockerfile` | Path to the Dockerfile relative to the repo root |
+| Input | Default | Description |
+|---|---|---|
+| `image_uri` | required | Image to scan. |
+| `dockerfile_path` | `Dockerfile` | Dockerfile context, or empty. |
+| `snyk_client_id` / `snyk_client_secret` | empty | OAuth credentials. |
+| `snyk_token` | empty | Deprecated static token. |
+| `severity` | `medium` | Minimum severity. |
+| `fail_on` | `upgradable` | Snyk failure policy. |
+| `policy_path` | `.snyk` | Policy file. |
+| `upload_sarif` | `true` | Upload to GitHub code scanning. |
 
-## Secrets
-
-`SNYK_CLIENT_ID` and `SNYK_CLIENT_SECRET` must be available in the
-calling repo. Set these at in the repository secrets and they'll be picked up
-automatically via `secrets: inherit`.
+SARIF upload requires `security-events: write` in the calling job.

--- a/.github/actions/image-scan/action.yml
+++ b/.github/actions/image-scan/action.yml
@@ -1,80 +1,185 @@
 name: Scan Image for Vulnerabilities
+description: Scan a container image with Snyk
 
-on:
-  workflow_call:
-    inputs:
-      image_uri:
-        description: "URI of image to scan"
-        required: true
-        type: string
-      dockerfile_path:
-        description: "Path to Dockerfile"
-        required: false
-        default: "Dockerfile"
-        type: string
-    secrets:
-      SNYK_CLIENT_ID:
-        required: true
-      SNYK_CLIENT_SECRET:
-        required: true
+inputs:
+  image_uri:
+    required: true
+    description: "URI of image to scan"
+  dockerfile_path:
+    required: false
+    description: "Path to the Dockerfile used to build the image"
+    default: "Dockerfile"
+  snyk_token:
+    required: false
+    description: "Deprecated Snyk API token; prefer OAuth client credentials"
+    default: ""
+  snyk_client_id:
+    required: false
+    description: "Snyk OAuth client ID"
+    default: ""
+  snyk_client_secret:
+    required: false
+    description: "Snyk OAuth client secret"
+    default: ""
+  severity:
+    required: false
+    description: "Minimum Snyk vulnerability severity"
+    default: "medium"
+  fail_on:
+    required: false
+    description: "Types of Snyk vulnerabilities that fail the scan"
+    default: "upgradable"
+  policy_path:
+    required: false
+    description: "Path to the Snyk policy file"
+    default: ".snyk"
+  upload_sarif:
+    required: false
+    description: "Upload the cleansed Snyk SARIF report to GitHub code scanning"
+    default: "true"
 
-jobs:
-  snyk:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      security-events: write
-      actions: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+runs:
+  using: "composite"
 
-      - name: Check Dockerfile exists
-        run: |
-          if [ ! -f "${{ inputs.dockerfile_path }}" ]; then
-            echo "::error::Dockerfile not found at ${{ inputs.dockerfile_path }}"
-            exit 1
-          fi
+  steps:
+  - name: Validate Snyk credentials
+    id: validate
+    env:
+      DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+      SNYK_CLIENT_ID: ${{ inputs.snyk_client_id }}
+      SNYK_CLIENT_SECRET: ${{ inputs.snyk_client_secret }}
+      SNYK_TOKEN: ${{ inputs.snyk_token }}
+    run: |
+      echo "oauth_required=false" >> "$GITHUB_OUTPUT"
+      echo "static_token_used=false" >> "$GITHUB_OUTPUT"
 
-      - name: Obtain Snyk OAuth token
-        id: snyk_auth
-        run: |
-          TOKEN=$(curl -s -X POST "https://api.snyk.io/oauth2/token" \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "grant_type=client_credentials" \
-            -d "client_id=${{ secrets.SNYK_CLIENT_ID }}" \
-            -d "client_secret=${{ secrets.SNYK_CLIENT_SECRET }}" \
-            | jq -r '.access_token')
-          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
-            echo "::error::Failed to obtain Snyk OAuth token"
-            exit 1
-          fi
-          echo "::add-mask::$TOKEN"
-          echo "snyk_token=$TOKEN" >> $GITHUB_OUTPUT
+      if [[ -n "$DOCKERFILE_PATH" && ! -f "$DOCKERFILE_PATH" ]]; then
+        echo "::error::Dockerfile not found at ${DOCKERFILE_PATH}"
+        exit 1
+      fi
 
-      - name: Install Snyk CLI
-        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # master
+      if [[ -z "$SNYK_TOKEN" ]] && { [[ -z "$SNYK_CLIENT_ID" ]] || [[ -z "$SNYK_CLIENT_SECRET" ]]; }; then
+        echo "::error::Provide either snyk_token or both snyk_client_id and snyk_client_secret."
+        exit 1
+      fi
 
-      - name: Snyk test
-        continue-on-error: true
-        env:
-          SNYK_OAUTH_TOKEN: ${{ steps.snyk_auth.outputs.snyk_token }}
-        run: snyk container test ${{ inputs.image_uri }} --severity-threshold=high --sarif-file-output=snyk.sarif --file=${{ inputs.dockerfile_path }}
+      if [[ -n "$SNYK_CLIENT_ID" && -n "$SNYK_CLIENT_SECRET" ]]; then
+        echo "oauth_required=true" >> "$GITHUB_OUTPUT"
+      else
+        echo "static_token_used=true" >> "$GITHUB_OUTPUT"
+      fi
+    shell: bash
 
-      - name: Snyk monitor
-        env:
-          SNYK_OAUTH_TOKEN: ${{ steps.snyk_auth.outputs.snyk_token }}
-        run: snyk container monitor ${{ inputs.image_uri }} --file=${{ inputs.dockerfile_path }}
+  - name: Obtain Snyk OAuth token
+    if: ${{ steps.validate.outputs.oauth_required == 'true' }}
+    id: snyk_auth
+    env:
+      SNYK_CLIENT_ID: ${{ inputs.snyk_client_id }}
+      SNYK_CLIENT_SECRET: ${{ inputs.snyk_client_secret }}
+    run: |
+      token=$(curl -s -X POST "https://api.snyk.io/oauth2/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "grant_type=client_credentials" \
+        -d "client_id=${SNYK_CLIENT_ID}" \
+        -d "client_secret=${SNYK_CLIENT_SECRET}" \
+        | jq -r '.access_token')
 
-      - name: Sanitise SARIF
-        if: always()
-        run: |
-          sed -i 's/"security-severity": "null"/"security-severity": "0"/g' snyk.sarif
-          sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' snyk.sarif
+      if [[ -z "$token" || "$token" == "null" ]]; then
+        echo "::error::Failed to obtain Snyk OAuth token"
+        exit 1
+      fi
 
-      - name: Upload SARIF
-        if: always() && hashFiles('snyk.sarif') != ''
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        with:
-          sarif_file: snyk.sarif
+      echo "::add-mask::$token"
+      echo "token=$token" >> "$GITHUB_OUTPUT"
+    shell: bash
+
+  - name: Install Snyk CLI
+    uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+
+  - name: Scan image with Snyk
+    id: snyk
+    continue-on-error: true
+    env:
+      DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+      IMAGE_URI: ${{ inputs.image_uri }}
+      POLICY_PATH: ${{ inputs.policy_path }}
+      SEVERITY: ${{ inputs.severity }}
+      SNYK_OAUTH_TOKEN: ${{ steps.snyk_auth.outputs.token }}
+      SNYK_TOKEN: ${{ inputs.snyk_token }}
+      FAIL_ON: ${{ inputs.fail_on }}
+    run: |
+      dockerfile_args=()
+      if [[ -n "$DOCKERFILE_PATH" ]]; then
+        dockerfile_args+=(--file="$DOCKERFILE_PATH")
+      fi
+
+      snyk container test "$IMAGE_URI" \
+        --org=legal-aid-agency \
+        --severity-threshold="$SEVERITY" \
+        --fail-on="$FAIL_ON" \
+        --sarif-file-output=snyk-report.sarif \
+        "${dockerfile_args[@]}" \
+        --policy-path="$POLICY_PATH"
+    shell: bash
+
+  - name: Cleanse Snyk SARIF report
+    if: ${{ inputs.upload_sarif == 'true' }}
+    run: |
+      jq '
+        .runs[].tool[].rules[]
+        |= (
+          if (
+            .properties["security-severity"] == null or
+            .properties["security-severity"] == "null" or
+            .properties["security-severity"] == "undefined" or
+            .properties["security-severity"] == ""
+          )
+          then .properties["security-severity"] =
+            (if .shortDescription.text | test("(?i)critical") then "9.0"
+             elif .shortDescription.text | test("(?i)high") then "7.0"
+             elif .shortDescription.text | test("(?i)medium") then "4.0"
+             elif .shortDescription.text | test("(?i)low") then "0.1"
+             else ""
+             end)
+          else .
+          end
+        )
+      ' snyk-report.sarif > snyk-report-cleansed.sarif
+    shell: bash
+
+  - name: Upload Snyk SARIF report
+    if: ${{ inputs.upload_sarif == 'true' }}
+    uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+    with:
+      sarif_file: snyk-report-cleansed.sarif
+
+  - name: Warn about deprecated SNYK_TOKEN usage
+    if: ${{ steps.validate.outputs.static_token_used == 'true' }}
+    run: |
+      echo "::warning title=Deprecated SNYK_TOKEN::A SNYK_TOKEN was used to authenticate with Snyk. Snyk recommends OAuth 2.0 service accounts (SNYK_CLIENT_ID + SNYK_CLIENT_SECRET). SNYK_TOKEN support will be removed in a future release."
+    shell: bash
+
+  - name: Add SNYK_TOKEN migration guidance to job summary
+    if: ${{ steps.validate.outputs.static_token_used == 'true' }}
+    run: |
+      {
+        echo "## ⚠️ Deprecated: SNYK_TOKEN"
+        echo ""
+        echo "Your workflow is using \`SNYK_TOKEN\` to authenticate with Snyk."
+        echo ""
+        echo "### Why migrate?"
+        echo "Snyk recommends OAuth 2.0 service accounts for CI/CD pipelines."
+        echo ""
+        echo "### How to migrate"
+        echo "Replace \`SNYK_TOKEN\` with \`SNYK_CLIENT_ID\` and \`SNYK_CLIENT_SECRET\`"
+        echo ""
+        echo "> 🚨 **\`SNYK_TOKEN\` support will be removed in a future release.**"
+      } >> "$GITHUB_STEP_SUMMARY"
+    shell: bash
+
+  - name: Fail if Snyk found vulnerabilities
+    if: ${{ steps.snyk.outcome == 'failure' }}
+    run: |
+      echo "Snyk found vulnerabilities, see code scanning outputs."
+      exit 1
+    shell: bash

--- a/.github/actions/semgrep-scan/README.md
+++ b/.github/actions/semgrep-scan/README.md
@@ -1,0 +1,15 @@
+# Semgrep scan
+
+Runs the repository-independent Semgrep `auto` ruleset against the caller's repository. The action
+checks out the repository and runs Semgrep in the `returntocorp/semgrep` container, so callers do
+not need to install Semgrep on their runner.
+
+The scan exits unsuccessfully when Semgrep reports a finding. It retains the existing exclusion
+for `python.django.security.django-no-csrf-token.django-no-csrf-token`.
+
+```yaml
+steps:
+  - uses: ministryofjustice/laa-reusable-github-actions/.github/actions/semgrep-scan@<immutable-sha>
+```
+
+The action is language-agnostic and can be used by any repository whose runner provides Docker.

--- a/.github/actions/semgrep-scan/action.yml
+++ b/.github/actions/semgrep-scan/action.yml
@@ -1,0 +1,21 @@
+name: "Semgrep scan"
+description: "Run a language-agnostic Semgrep security scan against the checked-out repository."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Run Semgrep scan
+      shell: bash
+      run: |
+        docker run --rm \
+          --volume "${GITHUB_WORKSPACE}:/src" \
+          --workdir /src \
+          --entrypoint semgrep \
+          returntocorp/semgrep \
+          scan \
+          --exclude-rule python.django.security.django-no-csrf-token.django-no-csrf-token \
+          --error \
+          --config auto

--- a/.github/workflows/cp-build-push-deploy.yml
+++ b/.github/workflows/cp-build-push-deploy.yml
@@ -12,6 +12,31 @@ on:
         required: false
         type: string
         default: Dockerfile #--Dockerfile in current working directory
+      build_mode:
+        description: "Image build mode: dockerfile or gradle-buildpacks"
+        required: false
+        type: string
+        default: dockerfile
+      java_version:
+        description: "Java version used for gradle-buildpacks builds"
+        required: false
+        type: string
+        default: '25'
+      java_distribution:
+        description: "Java distribution used for gradle-buildpacks builds"
+        required: false
+        type: string
+        default: temurin
+      jar_subproject:
+        description: "Gradle subproject containing the bootBuildImage task"
+        required: false
+        type: string
+        default: ''
+      docker_build_args:
+        description: "Additional arguments passed to Dockerfile builds"
+        required: false
+        type: string
+        default: ''
       app_name:
         description: "App Name"
         required: true
@@ -21,6 +46,11 @@ on:
         required: false
         type: string
         default: ${{ github.sha }}
+      additional_image_tags:
+        description: "JSON array of additional tags to apply to the image, e.g. '[\"latest\",\"stable\"]'"
+        required: false
+        type: string
+        default: "[]"
       dockerfile_requires_git:
         description: "Set to 'true' if the Dockerfile needs git access"
         required: false
@@ -51,12 +81,18 @@ on:
 
 jobs:
   build_and_push:
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/cp-build-push.yml@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/cp-build-push.yml@5abe13ef5cc59e8dc2e71f70a6c28cd7a836a97d # feat/java-pipeline-refactor 2026-07-13
     with:
       environment: ${{ inputs.environment }}
       dockerfile_path: ${{ inputs.dockerfile_path }}
+      build_mode: ${{ inputs.build_mode }}
+      java_version: ${{ inputs.java_version }}
+      java_distribution: ${{ inputs.java_distribution }}
+      jar_subproject: ${{ inputs.jar_subproject }}
+      docker_build_args: ${{ inputs.docker_build_args }}
       app_name: ${{ inputs.app_name }}
       image_tag: ${{ inputs.image_tag }}
+      additional_image_tags: ${{ inputs.additional_image_tags }}
       dockerfile_requires_git: ${{ inputs.dockerfile_requires_git }}
     secrets: inherit
 

--- a/.github/workflows/cp-build-push.yml
+++ b/.github/workflows/cp-build-push.yml
@@ -12,6 +12,31 @@ on:
         required: false
         type: string
         default: Dockerfile #--Dockerfile in current working directory
+      build_mode:
+        description: "Image build mode: dockerfile or gradle-buildpacks"
+        required: false
+        type: string
+        default: dockerfile
+      java_version:
+        description: "Java version used for gradle-buildpacks builds"
+        required: false
+        type: string
+        default: '25'
+      java_distribution:
+        description: "Java distribution used for gradle-buildpacks builds"
+        required: false
+        type: string
+        default: temurin
+      jar_subproject:
+        description: "Gradle subproject containing the bootBuildImage task"
+        required: false
+        type: string
+        default: ''
+      docker_build_args:
+        description: "Additional arguments passed to Dockerfile builds"
+        required: false
+        type: string
+        default: ''
       app_name:
         description: "App Name"
         required: true
@@ -64,9 +89,20 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #--v7.0.0
 
+    - name: Set up JDK ${{ inputs.java_version }}
+      if: ${{ inputs.build_mode == 'gradle-buildpacks' }}
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      with:
+        java-version: ${{ inputs.java_version }}
+        distribution: ${{ inputs.java_distribution }}
+
+    - name: Setup Gradle
+      if: ${{ inputs.build_mode == 'gradle-buildpacks' }}
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
     - name: ECR Auth
       id: auth
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@583a60502327d7b9b7701fdb11be9f7d096cf9f5 # SHA for main as of 12/06/2026
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@3529a4adc1f60cfe6584081795c3d3d917599a4a # feat/java-pipeline-refactor 2026-07-13
       with:
         ecr_region: ${{ vars.ECR_REGION }}
         ecr_role: ${{ secrets.ECR_ROLE_TO_ASSUME }}
@@ -74,9 +110,12 @@ jobs:
 
     - name: Build and Push
       id: build
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@de080adc3a989fe66cf999d57d32e7bb8d85624f # SHA for branch - TODO update to main once merged
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@3529a4adc1f60cfe6584081795c3d3d917599a4a # feat/java-pipeline-refactor 2026-07-13
       with:
+        build_mode: ${{ inputs.build_mode }}
         dockerfile_path: ${{ inputs.dockerfile_path }}
+        docker_build_args: ${{ inputs.docker_build_args }}
+        jar_subproject: ${{ inputs.jar_subproject }}
         image_registry: ${{ steps.auth.outputs.image_registry }}
         image_repo: ${{ vars.ECR_REPOSITORY }}
         image_tag: ${{ inputs.image_tag }}
@@ -89,7 +128,7 @@ jobs:
         echo image_registry=${{ steps.build.outputs.image_registry }} >> "$GITHUB_OUTPUT"
         echo image_repo=${{ steps.build.outputs.image_repo }} >> "$GITHUB_OUTPUT"
         echo image_tag=${{ steps.build.outputs.image_tag }} >> "$GITHUB_OUTPUT"
-        echo image_uri="${{ steps.build.outputs.image_registry }}/${{ steps.build.outputs.image_repo }}:${{ steps.build.outputs.image_tag }}" >> "$GITHUB_OUTPUT"
+        echo image_uri=${{ steps.build.outputs.image_uri }} >> "$GITHUB_OUTPUT"
 
     outputs:
       image_registry: ${{ steps.output.outputs.image_registry }}
@@ -99,10 +138,10 @@ jobs:
 
   scan:
     needs: build_push
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/sast.yml@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/sast.yml@3529a4adc1f60cfe6584081795c3d3d917599a4a # feat/java-pipeline-refactor 2026-07-13
     with:
       image_uri: ${{ needs.build_push.outputs.image_uri }}
-      dockerfile_path: ${{ inputs.dockerfile_path }}
+      dockerfile_path: ${{ inputs.build_mode == 'dockerfile' && inputs.dockerfile_path || '' }}
       ecr_session_name: "github-cicd-${{ inputs.app_name }}-scan-${{ github.run_number }}"
     secrets:
       SNYK_CLIENT_ID: ${{ secrets.SNYK_CLIENT_ID }}

--- a/.github/workflows/java-ecr-publish-image.yml
+++ b/.github/workflows/java-ecr-publish-image.yml
@@ -1,0 +1,176 @@
+name: Java - Publish image to ECR
+
+on:
+  workflow_call:
+    inputs:
+      java_version:
+        type: string
+        required: false
+        default: '25'
+      java_distribution:
+        type: string
+        required: false
+        default: temurin
+      image_version:
+        type: string
+        required: true
+      dockerfile_path:
+        type: string
+        required: false
+        default: ''
+      docker_build_args:
+        type: string
+        required: false
+        default: ''
+      jar_subproject:
+        type: string
+        required: false
+        default: ''
+      image_scan:
+        type: boolean
+        required: false
+        default: true
+      image_scan_severity:
+        type: string
+        required: false
+        default: medium
+      image_scan_fail_on:
+        type: string
+        required: false
+        default: upgradable
+      image_scan_policy_path:
+        type: string
+        required: false
+        default: .snyk
+      image_scan_upload_sarif:
+        type: boolean
+        required: false
+        default: true
+      publish:
+        type: boolean
+        required: false
+        default: true
+      tag_with_latest:
+        type: boolean
+        required: false
+        default: false
+    outputs:
+      published_image_version:
+        description: Version of the image published to ECR
+        value: ${{ jobs.publish-image.outputs.published_image_version }}
+    secrets:
+      ecr_region:
+        required: true
+      ecr_repository:
+        required: true
+      ecr_role_to_assume:
+        required: true
+      snyk_token:
+        required: false
+      snyk_client_id:
+        required: false
+      snyk_client_secret:
+        required: false
+      ecr_registry:
+        required: false
+      root_certificate:
+        required: false
+      binding_directory:
+        required: false
+      tls_keystore_password:
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+  security-events: write
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+    outputs:
+      published_image_version: ${{ steps.published.outputs.published_image_version }}
+    env:
+      ROOT_CERTIFICATE: ${{ secrets.root_certificate }}
+      TLS_KEYSTORE_PASSWORD: ${{ secrets.tls_keystore_password }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up JDK ${{ inputs.java_version }}
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: ${{ inputs.java_version }}
+          distribution: ${{ inputs.java_distribution }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
+      - name: Configure certificate binding
+        if: ${{ env.ROOT_CERTIFICATE != '' }}
+        env:
+          BINDING_DIRECTORY: ${{ secrets.binding_directory }}
+        run: |
+          test -n "$BINDING_DIRECTORY" || { echo "::error::A binding directory is required."; exit 1; }
+          mkdir -p "$BINDING_DIRECTORY"
+          echo "$ROOT_CERTIFICATE" > "$BINDING_DIRECTORY/root_cert.pem"
+          echo "ca-certificates" > "$BINDING_DIRECTORY/type"
+
+      - name: Assemble application
+        if: ${{ inputs.dockerfile_path != '' }}
+        run: ./gradlew assemble
+
+      - name: Authenticate with ECR
+        if: ${{ inputs.publish }}
+        id: ecr
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@3bc3739493639a3921c9b43b9dbbb5b5e02027cf # feat/java-pipeline-refactor 2026-07-22
+        with:
+          ecr_region: ${{ secrets.ecr_region }}
+          ecr_role: ${{ secrets.ecr_role_to_assume }}
+          role-session-name: reusable-image-${{ github.run_id }}-${{ github.run_attempt }}
+          account_ids: ${{ secrets.ecr_registry }}
+
+      - name: Build image
+        id: build
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@3bc3739493639a3921c9b43b9dbbb5b5e02027cf # feat/java-pipeline-refactor 2026-07-22
+        with:
+          image_registry: ${{ inputs.publish && steps.ecr.outputs.image_registry || 'registry' }}
+          image_repo: ${{ inputs.publish && secrets.ecr_repository || 'repository' }}
+          image_tag: ${{ inputs.image_version }}
+          build_mode: ${{ inputs.dockerfile_path != '' && 'dockerfile' || 'gradle-buildpacks' }}
+          dockerfile_path: ${{ inputs.dockerfile_path }}
+          docker_build_args: ${{ inputs.docker_build_args }}
+          jar_subproject: ${{ inputs.jar_subproject }}
+          additional_image_tags: ${{ inputs.tag_with_latest && '["latest"]' || '[]' }}
+          push: 'false'
+
+      - name: Scan image
+        if: ${{ inputs.image_scan }}
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/image-scan@3bc3739493639a3921c9b43b9dbbb5b5e02027cf # feat/java-pipeline-refactor 2026-07-22
+        with:
+          image_uri: ${{ steps.build.outputs.image_uri }}
+          dockerfile_path: ${{ inputs.dockerfile_path }}
+          snyk_token: ${{ secrets.snyk_token }}
+          snyk_client_id: ${{ secrets.snyk_client_id }}
+          snyk_client_secret: ${{ secrets.snyk_client_secret }}
+          severity: ${{ inputs.image_scan_severity }}
+          fail_on: ${{ inputs.image_scan_fail_on }}
+          policy_path: ${{ inputs.image_scan_policy_path }}
+          upload_sarif: ${{ inputs.image_scan_upload_sarif }}
+
+      - name: Publish image
+        if: ${{ inputs.publish }}
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/build-and-push@3bc3739493639a3921c9b43b9dbbb5b5e02027cf # feat/java-pipeline-refactor 2026-07-22
+        with:
+          image_registry: ${{ steps.ecr.outputs.image_registry }}
+          image_repo: ${{ secrets.ecr_repository }}
+          image_tag: ${{ inputs.image_version }}
+          dockerfile_path: ${{ inputs.dockerfile_path }}
+          additional_image_tags: ${{ inputs.tag_with_latest && '["latest"]' || '[]' }}
+          build: 'false'
+
+      - name: Summarise published image
+        id: published
+        if: ${{ inputs.publish }}
+        run: |
+          echo "published_image_version=${{ inputs.image_version }}" >> "$GITHUB_OUTPUT"
+          echo "Published image version: \`${{ inputs.image_version }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/java-gradle-build-and-publish.yml
+++ b/.github/workflows/java-gradle-build-and-publish.yml
@@ -1,0 +1,264 @@
+name: Java - Gradle build and publish
+
+on:
+  workflow_call:
+    inputs:
+      java_version:
+        type: string
+        required: false
+        default: '25'
+      java_distribution:
+        type: string
+        required: false
+        default: temurin
+      integration_test_task:
+        type: string
+        required: false
+        default: ''
+      build_command:
+        type: string
+        required: false
+        default: build
+      build_args:
+        type: string
+        required: false
+        default: ''
+      release_type:
+        type: string
+        required: false
+        default: ''
+      override_version:
+        type: string
+        required: false
+        default: ''
+      jacoco_coverage_report:
+        type: boolean
+        required: false
+        default: true
+      junit_results:
+        type: boolean
+        required: false
+        default: true
+      jacoco_coverage_report_path:
+        type: string
+        required: false
+        default: build/reports/jacoco
+      junit_results_path:
+        type: string
+        required: false
+        default: build/test-results
+      junit_report_path:
+        type: string
+        required: false
+        default: build/reports/tests
+      junit_report:
+        type: boolean
+        required: false
+        default: true
+      checkstyle_report:
+        type: boolean
+        required: false
+        default: true
+      checkstyle_report_path:
+        type: string
+        required: false
+        default: build/reports/checkstyle
+      semgrep_check:
+        type: boolean
+        required: false
+        default: false
+      github_bot_username:
+        type: string
+        required: false
+        default: github-actions-bot
+    outputs:
+      published_artifact_version:
+        description: Version published by this workflow
+        value: ${{ jobs.build-and-publish.outputs.published_artifact_version }}
+    secrets:
+      gh_token:
+        required: true
+      aws_region:
+        required: false
+      sonatype_username:
+        required: false
+      sonatype_password:
+        required: false
+      gpg_signing_key:
+        required: false
+      gpg_passphrase:
+        required: false
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  semgrep-scan:
+    if: ${{ inputs.semgrep_check }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ministryofjustice/laa-reusable-github-actions/.github/actions/semgrep-scan@3bc3739493639a3921c9b43b9dbbb5b5e02027cf # feat/java-pipeline-refactor 2026-07-22
+
+  build-and-publish:
+    needs: semgrep-scan
+    if: ${{ always() && (!inputs.semgrep_check || (needs.semgrep-scan.result != 'failure' && needs.semgrep-scan.result != 'cancelled')) }}
+    runs-on: ubuntu-latest
+    outputs:
+      published_artifact_version: ${{ steps.capture-version.outputs.published_artifact_version }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.gh_token }}
+      AWS_REGION: ${{ secrets.aws_region }}
+      SONATYPE_USERNAME: ${{ secrets.sonatype_username }}
+      SONATYPE_PASSWORD: ${{ secrets.sonatype_password }}
+      GPG_SIGNING_KEY: ${{ secrets.gpg_signing_key }}
+      GPG_PASSPHRASE: ${{ secrets.gpg_passphrase }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ secrets.gh_token }}
+
+      - name: Compute release version
+        id: compute
+        if: ${{ inputs.release_type != 'none' }}
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/compute-version@3bc3739493639a3921c9b43b9dbbb5b5e02027cf # feat/java-pipeline-refactor 2026-07-22
+        with:
+          bump: ${{ inputs.release_type != 'snapshot' && inputs.release_type || '' }}
+
+      - name: Compute snapshot version
+        id: snapshot
+        if: ${{ inputs.release_type == 'snapshot' && inputs.override_version == '' }}
+        env:
+          BUMP_TYPE: ${{ steps.compute.outputs.bump_type }}
+          MAJOR: ${{ steps.compute.outputs.major }}
+          MINOR: ${{ steps.compute.outputs.minor }}
+          PATCH: ${{ steps.compute.outputs.patch }}
+        run: |
+          set -euo pipefail
+          patch="$PATCH"
+          if [[ "$BUMP_TYPE" == "none" ]]; then patch=$((patch + 1)); fi
+          version="${MAJOR}.${MINOR}.${patch}-$(git rev-parse --short HEAD)-SNAPSHOT"
+          echo "snapshot_version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up JDK ${{ inputs.java_version }}
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: ${{ inputs.java_version }}
+          distribution: ${{ inputs.java_distribution }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
+      - name: Build and test
+        env:
+          BUILD_ARGS: ${{ inputs.build_args }}
+          BUILD_COMMAND: ${{ inputs.build_command }}
+        run: |
+          args=()
+          if [[ -n "$BUILD_ARGS" ]]; then read -r -a args <<< "$BUILD_ARGS"; fi
+          ./gradlew "$BUILD_COMMAND" "${args[@]}"
+
+      - name: Test coverage verification
+        if: ${{ inputs.jacoco_coverage_report }}
+        run: ./gradlew jacocoTestCoverageVerification
+
+      - name: Configure Testcontainers Docker API compatibility
+        run: echo "api.version=1.44" > ~/.docker-java.properties
+
+      - name: Integration test
+        if: ${{ inputs.integration_test_task != '' }}
+        run: ./gradlew "${{ inputs.integration_test_task }}"
+
+      - name: Create release tag
+        id: tag
+        if: ${{ inputs.release_type != 'snapshot' && steps.compute.outputs.next_version != '' }}
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/git-release@3bc3739493639a3921c9b43b9dbbb5b5e02027cf # feat/java-pipeline-refactor 2026-07-22
+        with:
+          tag: ${{ steps.compute.outputs.next_version }}
+          github_bot_username: ${{ inputs.github_bot_username }}
+          github_token: ${{ secrets.gh_token }}
+          create_github_release: 'false'
+
+      - name: Publish release artifact
+        if: ${{ steps.tag.outputs.gtag != '' }}
+        env:
+          VERSION: ${{ steps.tag.outputs.gtag }}
+        run: |
+          if [[ -n "$SONATYPE_USERNAME" && -n "$SONATYPE_PASSWORD" && -n "$GPG_SIGNING_KEY" && -n "$GPG_PASSPHRASE" ]]; then
+            ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Pversion="${VERSION#v}"
+          else
+            ./gradlew publish -Pversion="${VERSION#v}"
+          fi
+
+      - name: Create GitHub release
+        if: ${{ steps.tag.outputs.gtag != '' }}
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/git-release@3bc3739493639a3921c9b43b9dbbb5b5e02027cf # feat/java-pipeline-refactor 2026-07-22
+        with:
+          tag: ${{ steps.tag.outputs.gtag }}
+          github_bot_username: ${{ inputs.github_bot_username }}
+          github_token: ${{ secrets.gh_token }}
+
+      - name: Publish snapshot
+        if: ${{ inputs.release_type == 'snapshot' }}
+        env:
+          VERSION: ${{ inputs.override_version || steps.snapshot.outputs.snapshot_version }}
+        run: |
+          if [[ -n "$SONATYPE_USERNAME" && -n "$SONATYPE_PASSWORD" && -n "$GPG_SIGNING_KEY" && -n "$GPG_PASSPHRASE" ]]; then
+            ./gradlew publishToSonatype -Pversion="$VERSION"
+          else
+            ./gradlew publish -Pversion="$VERSION"
+          fi
+
+      - name: Capture published version
+        id: capture-version
+        env:
+          OVERRIDE_VERSION: ${{ inputs.override_version }}
+          RELEASE_TAG: ${{ steps.tag.outputs.gtag }}
+          SNAPSHOT_VERSION: ${{ steps.snapshot.outputs.snapshot_version }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$RELEASE_TAG" ]]; then
+            version="${RELEASE_TAG#v}"
+          elif [[ -n "$SNAPSHOT_VERSION" ]]; then
+            version="$SNAPSHOT_VERSION"
+          elif [[ -n "$OVERRIDE_VERSION" ]]; then
+            version="$OVERRIDE_VERSION"
+          else
+            version=$(grep '^version=' gradle.properties | cut -d= -f2)
+          fi
+          echo "published_artifact_version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Artifact version: \`${version}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload test results
+        if: ${{ inputs.junit_results }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results
+          path: ${{ inputs.junit_results_path }}
+          retention-days: 14
+
+      - name: Upload test report
+        if: ${{ inputs.junit_report }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-report
+          path: ${{ inputs.junit_report_path }}
+          retention-days: 14
+
+      - name: Upload Checkstyle report
+        if: ${{ inputs.checkstyle_report }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: checkstyle-report
+          path: ${{ inputs.checkstyle_report_path }}
+          retention-days: 14
+
+      - name: Upload JaCoCo coverage report
+        if: ${{ inputs.jacoco_coverage_report }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jacoco-coverage-report
+          path: ${{ inputs.jacoco_coverage_report_path }}
+          retention-days: 14

--- a/.github/workflows/mp-build-push.yml
+++ b/.github/workflows/mp-build-push.yml
@@ -42,11 +42,6 @@ on:
       image_uri:
         description: "Image Registry"
         value: ${{ jobs.build_push.outputs.image_uri }}
-    secrets:
-      SNYK_CLIENT_ID:
-        required: true
-      SNYK_CLIENT_SECRET:
-        required: true
 
 jobs:
   build_push:
@@ -87,21 +82,15 @@ jobs:
         echo image_tag=${{ steps.build.outputs.image_tag }} >> "$GITHUB_OUTPUT"
         echo image_uri="${{ steps.build.outputs.image_registry }}/${{ steps.build.outputs.image_repo }}:${{ steps.build.outputs.image_tag }}" >> "$GITHUB_OUTPUT"
 
+    - name: Image Scan
+      id: scan-post
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/image-scan@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
+      with:
+        image_uri: ${{ steps.output.outputs.image_uri }}
+        critical_high_exit_code: ${{ inputs.image_scan_critical_high_exit_code }}
+
     outputs:
       image_registry: ${{ steps.output.outputs.image_registry }}
       image_repo: ${{ steps.output.outputs.image_repo }}
       image_tag: ${{ steps.output.outputs.image_tag }}
       image_uri: ${{ steps.output.outputs.image_uri }}
-        
-  scan:
-    needs: build_push
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/sast.yml@0cb7eb8ab4bf643986ab36ecf3ffcdffa9b55214 # SHA for main as of 3 JUN 2026
-    with:
-      image_uri: ${{ needs.build_push.outputs.image_uri }}
-      dockerfile_path: ${{ inputs.dockerfile_path }}
-    secrets:
-      SNYK_CLIENT_ID: ${{ secrets.SNYK_CLIENT_ID }}
-      SNYK_CLIENT_SECRET: ${{ secrets.SNYK_CLIENT_SECRET }}        
-      # critical_high_exit_code: ${{ inputs.image_scan_critical_high_exit_code }}
-
-

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       dockerfile_path:
-        description: "Path to Dockerfile that will be used by Snyk to scan"
+        description: "Path to Dockerfile used by Snyk; set empty for images built without one"
         required: false
         default: "Dockerfile"
         type: string
@@ -88,7 +88,7 @@ jobs:
         env:
           INPUTS_DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
         run: |
-          if [ ! -f "${INPUTS_DOCKERFILE_PATH}" ]; then
+          if [[ -n "${INPUTS_DOCKERFILE_PATH}" && ! -f "${INPUTS_DOCKERFILE_PATH}" ]]; then
             echo "::error::Dockerfile not found at ${INPUTS_DOCKERFILE_PATH}, seems there isn't a container to scan"
             exit 1
           fi
@@ -113,7 +113,7 @@ jobs:
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04
 
       - name: Scan dependencies using container runtime
-        if: ${{ env.INPUTS_IMAGE_URI != '' }}
+        if: ${{ inputs.image_uri != '' }}
         env:
           SNYK_OAUTH_TOKEN: ${{ steps.auth.outputs.token }}
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -131,29 +131,37 @@ jobs:
           esac
 
           mkdir -p sarif
+          dockerfile_args=()
+          if [[ -n "${INPUTS_DOCKERFILE_PATH}" ]]; then
+            dockerfile_args+=(--file="${INPUTS_DOCKERFILE_PATH}")
+          fi
+
           if [ "${INPUTS_EXCLUDE_BASE_IMAGE_VULNS}" = "true" ]; then
             snyk container test "${INPUTS_IMAGE_URI}" \
               --severity-threshold="${MINIMUM_THRESHOLD}" \
               --sarif-file-output="sarif/snyk.sarif" \
-              --file="${INPUTS_DOCKERFILE_PATH}" \
+              "${dockerfile_args[@]}" \
               --exclude-base-image-vulns
           else
             snyk container test "${INPUTS_IMAGE_URI}" \
               --severity-threshold="${MINIMUM_THRESHOLD}" \
               --sarif-file-output="sarif/snyk.sarif" \
-              --file="${INPUTS_DOCKERFILE_PATH}"
+              "${dockerfile_args[@]}"
           fi
 
       - name: Monitor current dependencies
-        if: ${{ env.INPUTS_IMAGE_URI != '' }}
+        if: ${{ inputs.image_uri != '' }}
         env:
           SNYK_OAUTH_TOKEN: ${{ steps.auth.outputs.token }}
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           INPUTS_IMAGE_URI: ${{ inputs.image_uri }}
           INPUTS_DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
         run: |
-          snyk container monitor ${INPUTS_IMAGE_URI} \
-            --file=${INPUTS_DOCKERFILE_PATH}
+          dockerfile_args=()
+          if [[ -n "${INPUTS_DOCKERFILE_PATH}" ]]; then
+            dockerfile_args+=(--file="${INPUTS_DOCKERFILE_PATH}")
+          fi
+          snyk container monitor "${INPUTS_IMAGE_URI}" "${dockerfile_args[@]}"
 
       - name: Scan Infrastructure as Code files
         if: hashFiles(inputs.iac_path)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ See dedicated READMEs where available
 - [Build and Push Image (Modernisation Platform)](docs/README-mp-build-push.md)
 - [Deploy via Helm (Cloud Platform). For use with a dedicated generic-service helm chart](docs/README-cp-deploy.md)
 - [Build, Push and Deploy via Helm (Cloud Platform). For use with a dedicated generic-service helm chart](docs/README-cp-build-push-deploy.md)
+- [Java Gradle build and publish](docs/README-java-gradle-build-and-publish.md)
+- [Java image build, scan and ECR publish](docs/README-java-ecr-publish-image.md)
 
 ## Invoking a workflow
 
@@ -45,7 +47,11 @@ workflow on your remote repo by calling `ministryofjustice/laa-reusable-github-a
 - ecr-auth (bundled AWS and ECR auth)
 - helm-deploy (helm upgrade, for use with a dedicated generic-service helm chart)
 - helm-kube-score (kube-score via helm templating)
-- image-scan (trivy)
+- [build-and-push](.github/actions/build-and-push) (Dockerfile or Gradle buildpacks image build and publish)
+- [image-scan](.github/actions/image-scan) (Snyk container scanning)
+- [compute-version](.github/actions/compute-version) (release version computation from Conventional Commits)
+- [git-release](.github/actions/git-release) (idempotent Git tag and GitHub Release creation)
+- [semgrep-scan](.github/actions/semgrep-scan) (language-agnostic Semgrep security scanning)
 - secret-detection (trufflehog)
 
 ## Invoking an action

--- a/docs/README-cp-build-push-deploy.md
+++ b/docs/README-cp-build-push-deploy.md
@@ -2,6 +2,23 @@
 
 Build and push and Image to the Cloud Platform and then deploy it using using the laa-generic-service Helm Chart (WIP)
 
+The build uses a Dockerfile by default. Set `build_mode: gradle-buildpacks` to build a Spring Boot
+image with `bootBuildImage` before running the same Snyk scan and Helm deployment.
+
+## Build Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `dockerfile_path` | No | `Dockerfile` | Dockerfile used in `dockerfile` mode. |
+| `build_mode` | No | `dockerfile` | `dockerfile` or `gradle-buildpacks`. |
+| `java_version` | No | `25` | Java version used in `gradle-buildpacks` mode. |
+| `java_distribution` | No | `temurin` | Java distribution used in `gradle-buildpacks` mode. |
+| `jar_subproject` | No | `''` | Gradle subproject containing `bootBuildImage`. |
+| `docker_build_args` | No | `''` | Additional arguments used in `dockerfile` mode. |
+| `image_tag` | No | `${{ github.sha }}` | Primary image tag. |
+| `additional_image_tags` | No | `[]` | JSON array of additional image tags. |
+| `dockerfile_requires_git` | No | `false` | Provide Git credentials to the Docker build. |
+
 ## Required Repo Environment Variables/Secrets:
 
 ### Variables
@@ -44,5 +61,24 @@ jobs:
       helm_chart: ./laa-generic-helm-chart
       helm_values_path: ./helm/values.yaml
       k8s_service_account: cd-serviceaccount #--Requires CD service account created by CP
+    secrets: inherit
+```
+
+### Build a Spring Boot image and deploy it
+
+```yaml
+jobs:
+  cp_build_and_deploy:
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/cp-build-push-deploy.yml@main
+    with:
+      environment: dev
+      app_name: my-java-app
+      build_mode: gradle-buildpacks
+      java_version: '25'
+      java_distribution: temurin
+      jar_subproject: service
+      helm_release_name: my-java-app
+      helm_chart: ./laa-generic-helm-chart
+      helm_values_path: ./helm/values.yaml
     secrets: inherit
 ```

--- a/docs/README-cp-build-push.md
+++ b/docs/README-cp-build-push.md
@@ -2,6 +2,26 @@
 
 Build and push an image to the Cloud Platform, then run [sast workflow](./README-sast.md) and image vulnerability scanning via Snyk.
 
+The workflow builds from a Dockerfile by default. Set `build_mode: gradle-buildpacks` to build a
+Spring Boot image with `bootBuildImage`; this mode supports an optional Gradle subproject and does
+not require a Dockerfile.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `environment` | No | — | GitHub deployment environment. |
+| `dockerfile_path` | No | `Dockerfile` | Dockerfile used in `dockerfile` mode. |
+| `build_mode` | No | `dockerfile` | `dockerfile` or `gradle-buildpacks`. |
+| `java_version` | No | `25` | Java version used in `gradle-buildpacks` mode. |
+| `java_distribution` | No | `temurin` | Java distribution used in `gradle-buildpacks` mode. |
+| `jar_subproject` | No | `''` | Gradle subproject containing `bootBuildImage`. |
+| `docker_build_args` | No | `''` | Additional arguments used in `dockerfile` mode. |
+| `app_name` | Yes | — | Application name used in AWS session names. |
+| `image_tag` | No | `${{ github.sha }}` | Primary image tag. |
+| `additional_image_tags` | No | `[]` | JSON array of additional image tags. |
+| `dockerfile_requires_git` | No | `false` | Provide Git credentials to the Docker build. |
+
 ## Required Repo Environment Variables/Secrets:
 
 ### Variables
@@ -58,4 +78,19 @@ jobs:
     secrets: inherit
     with:
       app_name: my-app
+```
+
+### Build a Spring Boot image with Gradle buildpacks
+
+```yaml
+jobs:
+  build_and_push:
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/cp-build-push.yml@main
+    secrets: inherit
+    with:
+      app_name: my-java-app
+      build_mode: gradle-buildpacks
+      java_version: '25'
+      java_distribution: temurin
+      jar_subproject: service
 ```

--- a/docs/README-java-ecr-publish-image.md
+++ b/docs/README-java-ecr-publish-image.md
@@ -1,0 +1,88 @@
+# Java image build, scan and ECR publish workflow
+
+`java-ecr-publish-image.yml` builds a Java service image, optionally scans it with Snyk, and
+publishes it to ECR. Use `dockerfile_path` for a Dockerfile build; omit it for Spring Boot
+`bootBuildImage` and optionally select a Gradle `jar_subproject`.
+
+## Dockerfile image following a main release
+
+This is the Data Access pattern and can be repeated for secondary images such as a mass generator.
+
+```yaml
+jobs:
+  publish-image:
+    needs: release
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/java-ecr-publish-image.yml@<immutable-sha>
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
+    with:
+      dockerfile_path: Dockerfile
+      image_version: ${{ needs.release.outputs.published_artifact_version }}
+      image_scan: true
+    secrets:
+      ecr_repository: ${{ vars.ECR_REPOSITORY }}
+      ecr_region: ${{ vars.ECR_REGION }}
+      ecr_role_to_assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+      snyk_token: ${{ secrets.SNYK_TOKEN }}
+```
+
+## Gradle buildpacks image for a multi-module service
+
+This follows the Data Claims and Submit a Bulk Claim pattern. OAuth credentials are preferred for
+Snyk authentication.
+
+```yaml
+jobs:
+  publish-image:
+    needs: build-and-test
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/java-ecr-publish-image.yml@<immutable-sha>
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
+    with:
+      java_version: '25'
+      java_distribution: corretto
+      jar_subproject: 'claims-data:service'
+      image_version: ${{ format('{0}-{1}', vars.IMAGE_PREFIX, needs.build-and-test.outputs.published_artifact_version) }}
+      tag_with_latest: false
+    secrets:
+      ecr_repository: ${{ vars.ECR_REPOSITORY }}
+      ecr_region: ${{ vars.ECR_REGION }}
+      ecr_role_to_assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+      snyk_client_id: ${{ secrets.SNYK_CLIENT_ID }}
+      snyk_client_secret: ${{ secrets.SNYK_CLIENT_SECRET }}
+```
+
+The workflow builds without pushing, scans the local image, then publishes only after a successful
+scan. Set `publish: false` to build and scan without ECR publication.
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `java_version` | `25` | JDK version. |
+| `java_distribution` | `temurin` | JDK distribution. |
+| `image_version` | required | Primary image tag. |
+| `dockerfile_path` | empty | Dockerfile path; empty selects Gradle buildpacks. |
+| `docker_build_args` | empty | Additional Docker build arguments. |
+| `jar_subproject` | empty | Gradle subproject containing `bootBuildImage`. |
+| `image_scan` | `true` | Run Snyk container scanning. |
+| `image_scan_severity` | `medium` | Minimum Snyk severity. |
+| `image_scan_fail_on` | `upgradable` | Snyk `--fail-on` value. |
+| `image_scan_policy_path` | `.snyk` | Snyk policy path. |
+| `image_scan_upload_sarif` | `true` | Upload cleansed SARIF to code scanning. |
+| `publish` | `true` | Authenticate and push to ECR. |
+| `tag_with_latest` | `false` | Also publish `latest`. |
+
+## Secrets and output
+
+`ecr_region`, `ecr_repository` and `ecr_role_to_assume` are required. Scanning requires either
+OAuth (`snyk_client_id` plus `snyk_client_secret`) or the deprecated static `snyk_token`.
+`ecr_registry` supports a different registry account. Certificate bindings use
+`root_certificate`, `binding_directory` and optional `tls_keystore_password`.
+
+`published_image_version` is populated when `publish` is true and is suitable for downstream
+deployment jobs.

--- a/docs/README-java-gradle-build-and-publish.md
+++ b/docs/README-java-gradle-build-and-publish.md
@@ -1,0 +1,128 @@
+# Java Gradle build and publish workflow
+
+`java-gradle-build-and-publish.yml` is the standard entry point for Java repositories that build
+and publish with Gradle. It checks out full Git history, computes a version, builds and tests,
+optionally runs Semgrep and JaCoCo verification, publishes the artifact, creates a Git tag and
+GitHub Release, and uploads reports.
+
+Use an immutable commit SHA. Replace `<immutable-sha>` in the examples with the promoted commit
+from this repository.
+
+## Main-branch release
+
+This combines the release patterns used by Data Access, Data Claims and Submit a Bulk Claim.
+Downstream Pact, image and deployment jobs remain in the application repository and consume
+`published_artifact_version`.
+
+```yaml
+name: Build main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        type: choice
+        default: patch
+        options: [patch, minor, major]
+
+jobs:
+  release:
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/java-gradle-build-and-publish.yml@<immutable-sha>
+    permissions:
+      contents: write
+      packages: write
+    with:
+      java_version: '25'
+      java_distribution: corretto
+      build_command: ':service:assemble'
+      integration_test_task: integrationTest
+      release_type: ${{ inputs.release_type || '' }}
+      semgrep_check: true
+      jacoco_coverage_report: false
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  next-job:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Released ${{ needs.release.outputs.published_artifact_version }}"
+```
+
+An empty `release_type` on `main` derives major/minor/patch from Conventional Commits. Explicit
+`patch`, `minor` or `major` values override detection. Use `none` for build and test without
+publishing.
+
+## Feature or pull-request snapshot
+
+The workflow computes the snapshot version itself, so callers do not need a separate version job.
+
+```yaml
+name: Build feature
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/java-gradle-build-and-publish.yml@<immutable-sha>
+    permissions:
+      contents: write
+      packages: write
+    with:
+      java_version: '25'
+      release_type: snapshot
+      build_command: ':app:assemble'
+      integration_test_task: integrationTest
+      semgrep_check: true
+      jacoco_coverage_report_path: app/build/reports/jacoco
+      junit_results_path: app/build/test-results
+      junit_report_path: app/build/reports/tests
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-image:
+    needs: build-and-test
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/java-ecr-publish-image.yml@<immutable-sha>
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
+    with:
+      image_version: ${{ needs.build-and-test.outputs.published_artifact_version }}
+      jar_subproject: app
+    secrets: inherit
+```
+
+Supply `override_version` only when the repository has an established external preview-version
+format that must be retained.
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `java_version` | `25` | JDK version. |
+| `java_distribution` | `temurin` | JDK distribution understood by `setup-java`. |
+| `build_command` | `build` | Gradle task, including an optional subproject prefix. |
+| `build_args` | empty | Additional whitespace-separated Gradle arguments. |
+| `integration_test_task` | empty | Additional integration-test task. |
+| `release_type` | empty | `major`, `minor`, `patch`, `snapshot`, `none`, or empty auto-detection. |
+| `override_version` | empty | Explicit snapshot/output version. |
+| `semgrep_check` | `false` | Run the central Semgrep action before building. |
+| `jacoco_coverage_report` | `true` | Run JaCoCo verification and upload its report. |
+| `junit_results` / `junit_report` / `checkstyle_report` | `true` | Enable corresponding artifact uploads. |
+| `*_path` | Gradle defaults | Override report paths for multi-module builds. |
+| `github_bot_username` | `github-actions-bot` | Identity used for annotated release tags. |
+
+## Secrets and output
+
+`gh_token` is required. `aws_region` is optional and exposes `AWS_REGION` to Gradle for services
+whose build configuration requires it. Sonatype username/password and GPG key/passphrase are
+optional; provide all four to publish through Sonatype. Otherwise the workflow runs
+`./gradlew publish`.
+
+The `published_artifact_version` output contains the release version without `v`, or the complete
+snapshot version.

--- a/docs/README-sast.md
+++ b/docs/README-sast.md
@@ -48,7 +48,7 @@ change anything you don't need to.
 | Name | Required | Default | Description |
 |---|---|---|---|
 | `image_uri` | No | — | URI of the container image to scan. The workflow does not build the image; it must already exist. If omitted, the action won't do container scanning. |
-| `dockerfile_path` | No | `Dockerfile` | Path to the Dockerfile used by Snyk for context during container scanning. Relative to the top-level of the repository so unless you have a monorepo this is probably fine to leave |
+| `dockerfile_path` | No | `Dockerfile` | Path to the Dockerfile used by Snyk for context during container scanning. Set it to an empty string for an image built without a Dockerfile, such as a Gradle buildpacks image. |
 | `iac_path` | No | `""` | Path to Helm/IaC files. Leave unset to skip Infrastructure as Code scanning. |
 | `minimum_threshold` | No | `high` | Minimum severity level to report. One of: `low`, `medium`, `high`, `critical`. |
 | `exclude_base_image_vulns` | No | `false` | When `true`, appends `--exclude-base-image-vulns` to `snyk container test`. Useful when you want to focus on app-layer vulnerabilities and ignore base image findings. |


### PR DESCRIPTION
### Summary
Adds central reusable workflows and composite actions for Java build, release, image publishing and security scanning.

This provides a consistent pipeline for Java repositories while supporting both Dockerfile and Spring Boot buildpacks image builds. The implementation was informed by the existing Data Access, Data Claims and Submit a Bulk Claim pipelines.

**Changes**

- Adds java-gradle-build-and-publish.yml for:
  - Gradle build and test
  - Optional integration tests
  - Conventional Commit version calculation
  - Snapshot publishing
  - Major, minor and patch releases
  - Git tags and GitHub Releases
  - Sonatype publishing when Sonatype and GPG credentials are supplied
  - GitHub Packages or repository publishing fallback
  - Optional Semgrep and JaCoCo checks
  - Test, Checkstyle and coverage report uploads
  - Multi-module Gradle report paths

- Adds java-ecr-publish-image.yml for:
  - Dockerfile image builds
  - Spring Boot bootBuildImage builds
  - Multi-module Gradle projects
  - Snyk image scanning before publication
  - ECR authentication and publication
  - Optional latest tagging
  - Build-and-scan without publishing

- Adds reusable composite actions for:
  - Semantic version calculation from tags and Conventional Commits
  - Idempotent Git tag and GitHub Release creation
  - Repository-independent Semgrep scanning
  - Snyk image scanning with OAuth or static-token authentication

- Extends the existing build-and-push action with:
  - Dockerfile and Gradle buildpacks modes
  - Build and push controls
  - Additional image tags
  - Multi-module Gradle support

- Updates Cloud Platform and Modernisation Platform workflows to support the expanded image-build contract.

- Updates SAST and image scanning behaviour, including cleansed SARIF upload and delayed failure after reporting vulnerabilities.

- Adds README documentation and examples for all new Java workflows and actions, covering:
  - Main-branch releases
  - Feature and pull-request snapshots
  - Dockerfile builds following Data Access
  - Multi-module buildpacks builds following Data Claims and Submit a Bulk Claim
  - Sonatype, Semgrep, Snyk and report configuration

**Compatibility**

- Existing Dockerfile consumers retain the default build mode.
- Java-specific behaviour is opt-in through the new workflows or gradle-buildpacks mode.
- Deprecated CCMS release controls such as create_tag, is_snapshot and publish_package have not been introduced here.
- Sonatype is selected only when username, password, GPG key and GPG passphrase are all supplied; otherwise the workflow uses the repository’s normal Gradle publish task.